### PR TITLE
Fix for jake -T truncating things

### DIFF
--- a/lib/jake.js
+++ b/lib/jake.js
@@ -22,6 +22,7 @@ var JAKE_VERSION = '0.1.8'
   , args = process.argv.slice(2)
   , fs = require('fs')
   , path = require('path')
+  , sys = require('sys')
   , usage
   , parseopts = {}
   , optsReg
@@ -440,10 +441,12 @@ jake = new function () {
    * @param {String} str The message to print out before dying.
    */
   this.die = function (str) {
-    console.log(str);
+	var len = str.length, i;
+	for (i = 0; i < len; i+=25) {
+		sys.print(str.slice(i,i+25));
+	}
     process.exit();
   };
-
   /**
    * Displays the list of descriptions avaliable for tasks defined in
    * a Jakefile


### PR DESCRIPTION
I don't know if it's a super good solution, but something appeared to be wrong with just doing console.log(str) when str is really long. So instead I'm looping through the string and doing sys.print. It seems to work in my case. Hope that helps.
