### PR TITLE
recursive search for Jakefile in parent directories

### DIFF
--- a/lib/jake.js
+++ b/lib/jake.js
@@ -33,7 +33,18 @@ var JAKE_VERSION = '0.1.8'
   , jakefile
   , dirname
   , isCoffee
-  , exists
+  , exists = function () {
+      var cwd = process.cwd();
+
+      if (path.existsSync(jakefile) || path.existsSync(jakefile + '.js') || path.existsSync(jakefile + '.coffee')) {
+          return true;
+      }
+      process.chdir("..");
+      if (cwd === process.cwd()) {
+        return false;
+      }
+      return exists();
+  }
   , tasks;
 
 usage = ''
@@ -552,14 +563,11 @@ opts = Parser.opts;
 cmds = Parser.cmds;
 taskName = cmds.shift();
 dirname = opts.directory || process.cwd();
-
+process.chdir(dirname);
 taskName = taskName || 'default';
 
 jakefile = opts.jakefile ?
-    opts.jakefile.replace(/\.js$/, '').replace(/\.coffee$/, '') : dirname + '/Jakefile';
-if (jakefile[0] != '/') {
-  jakefile = path.join(dirname, jakefile);
-}
+    opts.jakefile.replace(/\.js$/, '').replace(/\.coffee$/, '') : 'Jakefile';
 
 if (opts.help) {
   jake.die(usage);
@@ -569,13 +577,13 @@ if (opts.version) {
   jake.die(JAKE_VERSION);
 }
 
-isCoffee = path.existsSync(jakefile + '.coffee');
-exists = path.existsSync(jakefile) || path.existsSync(jakefile + '.js') || isCoffee;
 
-if(!exists) {
+if (!exists()) {
   jake.die('Could not load Jakefile.\nIf no Jakefile specified with -f or --jakefile, ' +
-      'jake looks for Jakefile or Jakefile.js in the current directory.');
+      'jake looks for Jakefile or Jakefile.js in the current directory or one of the parent directories.');
 }
+
+isCoffee = path.existsSync(jakefile + '.coffee');
 
 try {
   if (isCoffee) {
@@ -586,7 +594,7 @@ try {
       jake.die('CoffeeScript is missing! Try `npm install coffee-script`');
     }
   }
-  tasks = require(jakefile);
+  tasks = require(path.join(process.cwd(), jakefile));
 }
 catch (e) {
   if (e.stack) {
@@ -599,7 +607,6 @@ if (opts.tasks) {
   jake.showAllTaskDescriptions();
 }
 else {
-  process.chdir(dirname);
   jake.runTask(taskName, cmds);
 }
 

--- a/tests/subdir/subsubdir/Jakefile.coffee
+++ b/tests/subdir/subsubdir/Jakefile.coffee
@@ -1,0 +1,6 @@
+sys = require('sys')
+
+desc 'This is the default task.'
+task 'default', [], (params) ->
+  console.log 'This is the default task from the coffee script Jakefile'
+  console.log(sys.inspect(arguments))


### PR DESCRIPTION
We migrated from rake to jake for building and this was a feature that I really missed from rake.

Added the recursive search to jake so it will find a Jakefile in any parent directory and use it (with that folder as the working directory).

Cheers!

Gord
