### PR TITLE
Docs say env vars are at the end of the arguments, so pop off the end of 

### DIFF
--- a/lib/parseargs.js
+++ b/lib/parseargs.js
@@ -113,7 +113,7 @@ parseargs.Parser.prototype = new function () {
 
     if (!preempt) {
       // Parse out any env-vars and task-name
-      while (!!(cmd = cmds.shift())) {
+      while (!!(cmd = cmds.pop())) {
         cmdItems = cmd.split('=');
         if (cmdItems.length > 1) {
           envVars[cmdItems[0]] = cmdItems[1];


### PR DESCRIPTION
Docs say env vars are at the end of the arguments, so pop off the end of the array rather than shift off the front.
