### PR TITLE
Program is not defined error when using CoffeeScript if the coffee-script module is not installed.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -53,7 +53,7 @@ Loader = function () {
         CoffeeScript = require('coffee-script');
       }
       catch (e) {
-        program.die('CoffeeScript is missing! Try `npm install coffee-script`');
+        fail('CoffeeScript is missing! Try `npm install coffee-script`');
       }
     }
     jakefile = path.join(process.cwd(), jakefile);


### PR DESCRIPTION
Changed program.die to fail so that the nice please install coffeescript is displayed.
This fixes #58.
