### PR TITLE
Improved error messages when a task or namespace is not found.

### DIFF
--- a/lib/jake.js
+++ b/lib/jake.js
@@ -150,7 +150,7 @@ jake = new function () {
         // No task found -- if it's the root, throw, because we know that
         // *should* be an existing task. Otherwise it could be a file prereq
         if (isRoot && !task) {
-          throw new Error('task not found');
+          throw new Error('Task "' + name + '" not found.');
         }
         else {
           if (includePrereqs && _taskHasPrereqs(prereqs)) {
@@ -225,6 +225,9 @@ jake = new function () {
     while (nameArr.length) {
       currName = nameArr.shift();
       ns = ns.childNamespaces[currName];
+      if(typeof ns === "undefined" || ns === null) {
+        fail('Cannot find the namespace "' + currName + '" for task "' + name + '".');
+      }
     }
 
     var task = ns.tasks[taskName];


### PR DESCRIPTION
I added an error message (rather than exception) when a namespace is not found and made the task not found error message more detailed so it is easier to investigate.
