### PR TITLE
Updating coffeescript sample to use current invoke syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,11 +369,11 @@ Here's an example:
     task 'default', (params) ->
       console.log 'Ths is the default task.'
       console.log(sys.inspect(arguments))
-      invoke 'new', []
+      jake.Task['new'].invoke []
 
     task 'new', ->
       console.log 'ello from new'
-      invoke 'foo:next', ['param']
+      jake.Task['foo:next'].invoke ['param']
 
     namespace 'foo', ->
       task 'next', (param) ->


### PR DESCRIPTION
Upon further examination of older jake.js commits, it appears the coffeescript sample is using the old invoke syntax from the September 2010 timeframe. Changed the same to use the current `jake.Task['something'].invoke` syntax. This pull request addresses issue #76.
