### PR TITLE
Fix dependency tracking of async file tasks

### DIFF
--- a/lib/jake.js
+++ b/lib/jake.js
@@ -250,8 +250,34 @@ jake = new function () {
       , prereqs
       , prereqName
       , prereqTask
+      , skipped
       , stats
       , modTime;
+
+    // Finalize the mod time of the previously processed file task, if any
+    if (_taskIndex > 0) {
+      name = _taskList[_taskIndex - 1].taskName;
+      task = this.getTask(name);
+
+      if (task instanceof FileTask) {
+        // The action may have created/modified the file
+        // ---------
+        // If there's a valid file at the end of running the task,
+        // use its mod-time as last modified
+        try {
+          stats = fs.statSync(task.name);
+          modTime = stats.ctime;
+        }
+        // If there's still no actual file after running the file-task,
+        // treat this simply as a plain task -- the current time will be
+        // the mod-time for anything that depends on this file-task
+        catch (e) {
+          modTime = new Date();
+        }
+
+        _modTimes[name] = modTime;
+      }
+    }
 
     // If there are still tasks to run, do it
     if (invocation) {
@@ -286,6 +312,7 @@ jake = new function () {
 
             // Compare mod-time of all the prereqs with the mod-time of this task
             if (prereqs.length) {
+              skipped = true;
               for (var i = 0, ii = prereqs.length; i < ii; i++) {
                 prereqName = prereqs[i];
                 prereqTask = this.getTask(prereqName);
@@ -295,22 +322,9 @@ jake = new function () {
                 // the one for this file (or this file doesn't exist yet)
                 if ((prereqTask && !(prereqTask instanceof FileTask || prereqTask instanceof DirectoryTask))
                     || (!modTime || _modTimes[prereqName] >= modTime)) {
+                  skipped = false;
                   if (typeof task.action == 'function') {
                     task.action.apply(task, args || []);
-                    // The action may have created/modified the file
-                    // ---------
-                    // If there's a valid file at the end of running the task,
-                    // use its mod-time as last modified
-                    try {
-                      stats = fs.statSync(task.name);
-                      modTime = stats.ctime;
-                    }
-                    // If there's still no actual file after running the file-task,
-                    // treat this simply as a plain task -- the current time will be
-                    // the mod-time for anything that depends on this file-task
-                    catch (e) {
-                      modTime = new Date();
-                    }
                   }
                   break;
                 }
@@ -325,8 +339,8 @@ jake = new function () {
 
             _modTimes[name] = modTime;
 
-            // Async tasks call this themselves
-            if (!task.async) {
+            // Async tasks call this themselves, provided that we haven't skipped them
+            if (!task.async || skipped) {
               complete();
             }
 


### PR DESCRIPTION
Hey! Great work on Jade.

Async file tasks have two bugs fixed by this patch:

1) if a task is skipped, complete() isn't being called at all

2) if a task is executed, updated file mod time isn't recorded
