### PR TITLE
Deleting node-glob dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,13 +335,13 @@ This will automatically create a 'package' task that will assemble the specified
 
 PackageTask also creates a 'clobberPackage' task that removes the pkg/ directory, and a 'repackage' task that forces the package to be rebuilt.
 
-PackageTask requires NodeJS's glob module (https://github.com/isaacs/node-glob). It is used in FileList, which is used to specify the list of files to include in your PackageTask (the packageFiles property). (See FileList, below.)
+PackageTask requires NodeJS's minimatchmodule (https://github.com/isaacs/minimatch). It is used in FileList, which is used to specify the list of files to include in your PackageTask (the packageFiles property). (See FileList, below.)
 
 ### FileList
 
 Jake's FileList takes a list of glob-patterns and file-names, and lazy-creates a list of files to include. Instead of immediately searching the filesystem to find the files, a FileList holds the pattern until it is actually used.
 
-When any of the normal JavaScript Array methods (or the `toArray` method) are called on the FileList, the pending patterns are resolved into an actual list of file-names. FileList uses NodeJS's glob module (https://github.com/isaacs/node-glob).
+When any of the normal JavaScript Array methods (or the `toArray` method) are called on the FileList, the pending patterns are resolved into an actual list of file-names. FileList uses NodeJS's minimatchmodule (https://github.com/isaacs/minimatch).
 
 To build the list of files, use FileList's `include` and `exclude` methods:
 

--- a/lib/file_list.js
+++ b/lib/file_list.js
@@ -15,8 +15,18 @@
  * limitations under the License.
  *
 */
-var fs = require('fs')
-  , glob; // Lazy-required
+var fs = require('fs'),
+	path = require('path'),
+	minimatch; // Lazy-required
+var glob = {};
+
+glob.globSync = function(pattern){
+	var directory = path.dirname(pattern),
+		files = fs.readdirSync(directory);
+		file_pattern = path.basename(pattern);
+
+	return minimatch.match(files,file_pattern);
+};
 
 // Constants
 // ---------------
@@ -66,13 +76,17 @@ var FileList = function () {
   var self = this
     , wrap;
 
-  // Lazy-require glob so that require of this file in cli.js won't bomb
-  if (!glob) {
+  // Lazy-require minimatch so that require of this file in cli.js won't bomb
+  if (!minimatch) {
     try {
-      glob = require('glob');
+      minimatch = require('minimatch');
+	  var path = require('path'),
+	  	  fs = require('fs');
+		  
+
     }
     catch(e) {
-      fail('FileList requires glob (https://github.com/isaacs/node-glob). Try `npm install glob`.');
+      fail('FileList requires minimatch (https://github.com/isaacs/minimatch). Try `npm install minimatch`.');
     }
   }
 


### PR DESCRIPTION
node-glob depency has been changed to minimatch to be compatible with nodeJS > 0.5.x
