### PR TITLE
2 file tasks that share same dependency, when invoked, are not both executed

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -112,7 +112,7 @@ TaskBase = new (function () {
       }
 
       // Do when done
-      prereq.addListener('complete', function () {
+      prereq.once('complete', function () {
         self.handlePrereqComplete(prereq);
       });
       prereq.invoke.apply(prereq, parsed.args);


### PR DESCRIPTION
```
var fs = require('fs');
task('default', function(){})

desc('1')
file('1', ['a','b'], function() {
    fs.writeFile('1', 'data', 'utf8', function(err) {
        console.log('1');
        complete();
    });
}, {async: true})

desc('2')
file('2', ['a','c'], function() {
    fs.writeFile('2', 'data', 'utf8', function(err) {
        console.log('2');
        complete();
    });
}, {async: true})

desc('async')
task('async', function() {
    var t1 = jake.Task['1'];
    var t2 = jake.Task['2'];
    t1.on('complete', function(){t2.invoke()})
    t2.on('complete', function() {console.log('complete'); complete(); })
    t1.invoke();
}, {async: true})
```

```
$ touch a b c
```

Try above code with and without patch after `touch`ing above files
Without patch, only task '1' executes. With patch, both tasks execute as expected
