### PR TITLE
jake.exec: don't wrap DOS command in double-quotes

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,8 +78,7 @@ utils = new (function () {
         // Ganking part of Node's child_process.exec to get cmdline args parsed
         if (process.platform == 'win32') {
           cmd = 'cmd.exe';
-          // TODO: Escape double-quotes?
-          args = ['/s', '/c', '"' + next + '"'];
+          args = ['/s', '/c', next];
         }
         else {
           cmd = '/bin/sh';


### PR DESCRIPTION
Wrapping in double-quotes is not required by cmd.exe and actually
prevents the command from being executed. For some reason, when the
command is actually executed, the double-quotes are escaped with a
preceding backslash.

Note: I only tested this on an XP virtual machine running on Ubuntu.
