### PR TITLE
Make jake.exec support streaming output on Windows

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -131,60 +131,43 @@ utils = new (function () {
         , errData = '';
       // Keep running as long as there are commands in the array
       if (next) {
-        // If you're on Windows, no streaming output for you,
-        // just use exec
-        if (process.platform == 'win32') {
-          exec(next, function (err, stdout, stderr) {
-            if (err && breakOnError) {
-              fail(err);
-            }
-            else {
-              if (printStderr) {
-                console.error(stderr);
-              }
-              if (printStdout) {
-                console.log(stdout);
-              }
-              run();
-            }
-          });
-        }
-        // POSIX platform gets streaming output for shell-commands
         // Ganking part of Node's child_process.exec to get cmdline args parsed
-        else {
-          cmd = '/bin/sh';
-          args = ['-c', next];
+        cmd = '/bin/sh';
+        args = ['-c', next];
+        if (process.platform == 'win32') {
+          cmd = 'cmd';
+          args = ['/c', next];
+        }
 
-          // Spawn a child-process, set up output
-          sh = spawn(cmd, args);
-          // Out
-          if (printStdout) {
-            sh.stdout.on('data', function (data) {
-              console.log(_truncate(data.toString()));
-            });
-          }
-          // Err
-          sh.stderr.on('data', function (data) {
-            var d = data.toString();
-            if (printStderr) {
-              console.error(_truncate(d));
-            }
-            // Accumulate the error-data so we can use it as the
-            // stack if the process exits with an error
-            errData += d;
-          });
-          // Exit, handle err or run next
-          sh.on('exit', function (code) {
-            var msg = errData || 'Process exited with error.';
-            msg = _trim(msg);
-            if (breakOnError && code != 0) {
-              fail(msg, code);
-            }
-            else {
-              run();
-            }
+        // Spawn a child-process, set up output
+        sh = spawn(cmd, args);
+        // Out
+        if (printStdout) {
+          sh.stdout.on('data', function (data) {
+            console.log(_truncate(data.toString()));
           });
         }
+        // Err
+        sh.stderr.on('data', function (data) {
+          var d = data.toString();
+          if (printStderr) {
+            console.error(_truncate(d));
+          }
+          // Accumulate the error-data so we can use it as the
+          // stack if the process exits with an error
+          errData += d;
+        });
+        // Exit, handle err or run next
+        sh.on('exit', function (code) {
+          var msg = errData || 'Process exited with error.';
+          msg = _trim(msg);
+          if (breakOnError && code != 0) {
+            fail(msg, code);
+          }
+          else {
+            run();
+          }
+        });
       }
       else {
         if (typeof callback == 'function') {


### PR DESCRIPTION
When you specify the `stdout: true` and/or `stderr: true` options to `jake.exec`, and `jake.exec` detects that it's running on Windows, it currently makes two behavior changes: it doesn't stream the output as the external command executes (instead waiting until the process exits to display any output); and it doesn't display any output at all if the external command returned a nonzero exit code. The former is an inconvenience; the latter is a serious loss of functionality, because without any output, you can't tell why your jake task failed.

These changes fix both problems by making Windows use `child_process.spawn` just like other platforms already did; and using a platform-specific shell (`cmd /c` on Windows, or the existing `sh -c` everywhere else).

I'm not wild about hard-coding the shell command per-platform, but I've seen other Node.js code that uses the same technique (e.g. [`npm/lib/utils/lifecycle.js`](https://github.com/isaacs/npm/blob/master/lib/utils/lifecycle.js)), and seeing the output of build tasks seems worth the change.
