### PR TITLE
CoffeeScript support for .jake.coffee files in jakelib

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -24,7 +24,7 @@ var path = require('path')
 
 Loader = function () {
 
-  var JAKEFILE_PAT = /\.jake$/;
+  var JAKEFILE_PAT = /\.jake(\.js|\.coffee)?$/;
 
   var _loadJakefile = function (file) {
         var jakefile = file ?
@@ -56,12 +56,7 @@ Loader = function () {
 
         isCoffee = path.existsSync(jakefile + '.coffee');
         if (isCoffee) {
-          try {
-            CoffeeScript = require('coffee-script');
-          }
-          catch (e) {
-            fail('CoffeeScript is missing! Try `npm install coffee-script`');
-          }
+          CoffeeScript = _requireCoffee();
         }
         require(fileUtils.absolutize(jakefile));
       }
@@ -74,9 +69,21 @@ Loader = function () {
           dirlist = fs.readdirSync(dirname);
           dirlist.forEach(function (filePath) {
             if (JAKEFILE_PAT.test(filePath)) {
+              if (/\.coffee$/.test(filePath)) {
+                CoffeeScript = _requireCoffee();
+              }
               require(path.join(dirname, filePath));
             }
           });
+        }
+      }
+
+      , _requireCoffee = function() {
+        try {
+          return require('coffee-script');
+        }
+        catch (e) {
+          fail('CoffeeScript is missing! Try `npm install coffee-script`');
         }
       };
 


### PR DESCRIPTION
CoffeeScript is only supported by Jakefile.coffee now.

The .jake files in jakelib can only support JavaScript, so I hacked the "loader.js" file to let it support the files end with .jake.coffee to require coffee-script.

Moreover, because Jakefile support pattern like "Jakefile.js", I also change the JAKEFILE_PAT to /.jake(.js|.coffee)?$/ . I think it will be more friendly for syntax highlight in editors.
