### PR TITLE
Task.reenable is broken for FileTasks or tasks with FileTasks as prereqs

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -167,7 +167,7 @@ TaskBase = new (function () {
     var prereqs
       , prereq;
     this.done = false;
-    if (deep) {
+    if (deep && this.prereqs) {
       prereqs = this.prereqs;
       for (var i = 0, ii = prereqs.length; i < ii; i++) {
         prereq = jake.Task[prereqs[i]];


### PR DESCRIPTION
When you try to `.reenable()` a FileTask with a file list, or `.reenable(true)` a `Task` with a `FileTask` as a prerequisite, you currently get an error that says something like "cannot access property 'length' of undefined". I went ahead and fixed this behavior.

I also had a patch to make it so `.reenable()` on a `FileTask` would cause that task to re-check the modification times on its prerequisite files, because that seemed like a reasonable behavior, but I decided there were other ways to work around that issue (for example with `fs.watchFile`) - so it isn't included in this pull request.

As a bit of context, this issue came up when I was working on a "watch" task that would continuously monitor the project and rebuild as files changed... https://gist.github.com/2830614 if you are interested.
