### PR TITLE
add the chaining support for FileList

### DIFF
--- a/lib/file_list.js
+++ b/lib/file_list.js
@@ -206,6 +206,7 @@ FileList.prototype = new (function () {
     for (var i = 0, ii = args.length; i < ii; i++) {
       this.pendingAdd.push(args[i]);
     }
+    return this;
   };
 
   /**
@@ -246,6 +247,7 @@ FileList.prototype = new (function () {
     if (!this.pending) {
       _resolveExclude.call(this);
     }
+    return this;
   };
 
   /**
@@ -261,6 +263,7 @@ FileList.prototype = new (function () {
       }
       _resolveExclude.call(this);
     }
+    return this;
   };
 
   /**
@@ -281,6 +284,7 @@ FileList.prototype = new (function () {
     , funcs: []
     , regex: null
     };
+    return this;
   };
 
 })();


### PR DESCRIPTION
the FileList could write like

``` javascript
var list = new jake.FileList();
list.include("test/*.js")
    .include("test/*.coffee")
    .exclude("test/test.js");
```
