### PR TITLE
Consider implementing jake.defaults to make lazy people happier

### DIFF
--- a/lib/jake.js
+++ b/lib/jake.js
@@ -221,4 +221,9 @@ jake.FileTask = FileTask;
 jake.DirectoryTask = DirectoryTask;
 jake.Namespace = Namespace;
 
+// initialise some defaults
+jake.defaults = {
+  async: false
+};
+
 module.exports = jake;

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -66,7 +66,7 @@ TaskBase = new (function () {
     this.name = name;
     this.prereqs = prereqs;
     this.action = action;
-    this.async = false;
+    this.async = jake.defaults.async;
     this.done = false;
     this.fullName = null;
     this.description = null;
@@ -80,7 +80,7 @@ TaskBase = new (function () {
     }
     else {
       if (opts.async) {
-        this.async = true;
+        this.async = opts.async;
       }
     }
   };


### PR DESCRIPTION
Not sure if this is something that you want to implement, but I've tried using it locally in a build process and it has certainly saved writing `{ async: true }` for each of the tasks in more complicated builds where most of the operations are asynchronous. 
