### PR TITLE
Fix needZip PackageTask when using archiveChangeDir.

### DIFF
--- a/lib/package_task.js
+++ b/lib/package_task.js
@@ -223,10 +223,8 @@ PackageTask.prototype = new (function () {
     task('repackage', ['package']);
 
     task('clobberPackage', function () {
-      jake.exec(['rm -fr ' + self.packageDir], function () {
-        complete();
-      });
-    }, {async: true});
+      jake.rmRf(self.packageDir);
+    });
 
     desc('Remove the package');
     task('clobber', ['clobberPackage']);
@@ -234,8 +232,8 @@ PackageTask.prototype = new (function () {
     for (var p in _compressOpts) {
       if (this['need' + p]) {
         (function (p) {
-          var filename = self.packageDir + '/' + self.packageName() +
-              _compressOpts[p].ext;
+          var filename = path.resolve(self.packageDir + '/' + self.packageName() +
+              _compressOpts[p].ext);
           compressTaskArr.push(filename);
 
           file(filename, [packageDirPath], function () {
@@ -247,19 +245,23 @@ PackageTask.prototype = new (function () {
 
             // Move into the package dir to compress (see below, after
             // exec)
-            process.chdir(self.packageDir);
+            var chdir = self.packageDir;
 
             cmd = self[opts.cmd + 'Command'];
             cmd += ' -' + opts.flags;
             if (opts.cmd == 'jar' && self.manifestFile) {
               cmd += 'm';
             }
-            cmd += ' ' + self.packageName() + opts.ext;
+            cmd += ' ' + filename;
             if (opts.cmd == 'jar' && self.manifestFile) {
               cmd += ' ' + self.manifestFile;
             }
             if (self.archiveChangeDir) {
-              cmd += ' -C ' + self.archiveChangeDir;
+                if(opts.cmd === 'zip') {
+                    chdir = path.join(chdir,self.archiveChangeDir);
+                } else {
+                    cmd += ' -C ' + self.archiveChangeDir;
+                }
             }
             if (self.archiveContentDir) {
               cmd += ' ' + self.archiveContentDir;
@@ -268,6 +270,7 @@ PackageTask.prototype = new (function () {
               cmd += ' ' + self.packageName();
             }
 
+            process.chdir(chdir);
             exec(cmd, function (err, stdout, stderr) {
               if (err) { throw err; }
 


### PR DESCRIPTION
-C is not a supported command line option for zip.
Used chdir when packaging as zip.
Also changed jake.exec('rm -fr') to use jake.rmRf() instead for cross-platform compatability.
