### PR TITLE
File task fix

### DIFF
--- a/lib/task/file_task.js
+++ b/lib/task/file_task.js
@@ -95,7 +95,7 @@ FileBase = new (function () {
       this.modTime = stats.mtime;
     // File does not exist so we set a really high
     // modTime so that this file task will trigger
-    // any task it's a prerequisite to to run.
+    // any task it's a prerequisite of to run.
     } catch (error) {
       this.modTime = Infinity;
     }


### PR DESCRIPTION
This resolves the "file not found" errors for file tasks. See [issue 151](https://github.com/mde/jake/issues/151) for examples and background.

Tested on a Windows 7 machine.
