### PR TITLE
Allow files to be globbed from absolute paths:

### DIFF
--- a/lib/file_list.js
+++ b/lib/file_list.js
@@ -21,8 +21,33 @@ var fs = require('fs')
 , utils = require('utilities')
 , globSync;
 
+var globPattern = /[*?\[\{]/;
+
+// Returns the base directory that does not
+// contain a glob pattern.
+var basedir = function (p) {
+  var segment
+    , segments = (p || '').split(/\\|\//)
+    , base = jake.isAbsolute(p) ? '' : '.';
+
+  for (var i=0; i<segments.length; i++) {
+    segment = segments[i];
+
+    // If the segment has an glob pattern, return parent directory
+    if (globPattern.test(segment)) {
+      return base;
+    }
+    // Otherwise add this segment to the path
+    else {
+      base += segment==='' ? '' : ('/' + segment);
+    }
+  };
+  // no wildcards found, return dirname
+  return path.dirname(base);
+};
+
 globSync = function (pat) {
-  var dirname = jake.basedir(pat)
+  var dirname = basedir(pat)
     , files = jake.readdirR(dirname)
     , matches;
   pat = path.normalize(pat);
@@ -116,7 +141,6 @@ var FileList = function () {
 };
 
 FileList.prototype = new (function () {
-  var globPattern = /[*?\[\{]/;
 
   var _addMatching = function (pat) {
         var matches = globSync(pat);


### PR DESCRIPTION
jake.basedir in `utilities` would return '/' if 
an absolute path was given to FileList. This means
jake would try to read the entire filesystem (which
in my case failed with permission errors). Also,
this function only returns the first segment of the 
path, so that if you wanted to glob `lib/models/*.js`
say, it would read the entire `lib` directory, 
instead of `lib/models`.

I pulled this function inline (I'm not sure what 
else depends on the existing functionality), and
made it return the deepest directory that does
not contain a glob character.
