### PR TITLE
printStdout/printStderr in jake.exec uses console.log which may incorrectly append extra newline characters

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -162,20 +162,19 @@ utils.mixin(Exec.prototype, new (function () {
           // Out
           sh.stdout.on('data', function (data) {
             if (config.printStdout) {
-              console.log(utils.string.rtrim(data.toString()));
+              process.stdout.write(data);
             }
             self.emit('stdout', data);
           });
           // Err
           sh.stderr.on('data', function (data) {
-            var d = data.toString();
             if (config.printStderr) {
-              console.error(utils.string.rtrim(d));
+              process.stderr.write(data);
             }
             self.emit('stderr', data);
             // Accumulate the error-data so we can use it as the
             // stack if the process exits with an error
-            errData += d;
+            errData += data.toString();
           });
           // Exit, handle err or run next
           sh.on('exit', function (code) {


### PR DESCRIPTION
Hi!
I recently decided to make a jake task for running jshint and reporting an xml of the results to the stdout using something like `jake.exec("jshint --reporter=checkstyle rest goes here", {printStdout: true, printStderr: true})` and doing standard output UNIX redirection with something like `jake jshint > output.xml`.
When I did this and tried to integrate with other tools I noticed that they were failing to parse the generated file because there were some "mysterious" linefeed characters inserted in the xml file where they should not exist like

```
<node foo="bar" />
<node fo
o="bar" />
```

So I checked jake's code and found out that it is calling `console.log` (which appends a newline character) on every `stream.on('stdout', ...)` event. I suppose jshint in this case is forcing the flush of data in block units (rather than lines) which causes jake to append newline characters erroneously.

I am appending a patch that simply does process.stdout.write directly. I am still wondering if we should take care of stream.drain events or simply use stream.pipe, but I don't think it is a problem like now. I tried writing a test case but then noticed that I would need to use something like sinon (which would introduce a new dependency) to stub console.log and make sure the data is being written to stdout correctly without extra newline characters.

I would be happy if you could pull this into jake repository.
Thank you in advance.
