### PR TITLE
Do not include this.packageDir into the package.

### DIFF
--- a/lib/package_task.js
+++ b/lib/package_task.js
@@ -303,8 +303,7 @@ PackageTask.prototype = new (function () {
 
     directory(this.packageDir);
 
-    file(packageDirPath,
-        FileList.clone(this.packageFiles).include(this.packageDir), function () {
+    file(packageDirPath, this.packageFiles, function () {
       var fileList = [];
       self.packageFiles.forEach(function (name) {
         var f = path.join(self.packageDirPath(), name)


### PR DESCRIPTION
Quick fix for #171.

Not sure if it's dev code left behind or feature, but definitely something unexpected. What was the point behind it?
