### PR TITLE
Use .gitignore to exclude dependencies from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Git wants to add `node_modules/...` after you run `npm install`, so I excluded them with a `.gitignore`.
