### PR TITLE
Refactored away some JSHint warnings

### DIFF
--- a/lib/file_list.js
+++ b/lib/file_list.js
@@ -171,7 +171,7 @@ FileList.prototype = new (function () {
         this.items = this.items.filter(function (name) {
           return !self.shouldExclude(name);
         });
-      }
+      };
 
   /**
    * Includes file-patterns in the FileList. Should be called with one or more

--- a/lib/jake.js
+++ b/lib/jake.js
@@ -75,7 +75,7 @@ utils.mixin(jake, new (function () {
   // Saves the description created by a 'desc' call that prefaces a
   // 'task' call that defines a task.
   this.currentTaskDescription = null;
-  this.program = new Program()
+  this.program = new Program();
   this.FileList = require('./file_list').FileList;
   this.PackageTask = require('./package_task').PackageTask;
   this.NpmPublishTask = require('./npm_publish_task').NpmPublishTask;
@@ -115,7 +115,8 @@ utils.mixin(jake, new (function () {
    * a Jakefile
    */
   this.showAllTaskDescriptions = function (f) {
-    var maxTaskNameLength = 0
+    var p
+      , maxTaskNameLength = 0
       , task
       , str = ''
       , padding
@@ -123,7 +124,7 @@ utils.mixin(jake, new (function () {
       , descr
       , filter = typeof f == 'string' ? f : null;
 
-    for (var p in jake.Task) {
+    for (p in jake.Task) {
       task = jake.Task[p];
       // Record the length of the longest task name -- used for
       // pretty alignment of the task descriptions
@@ -131,7 +132,7 @@ utils.mixin(jake, new (function () {
         p.length : maxTaskNameLength;
     }
     // Print out each entry with descriptions neatly aligned
-    for (var p in jake.Task) {
+    for (p in jake.Task) {
       if (filter && p.indexOf(filter) == -1) {
         continue;
       }
@@ -142,7 +143,7 @@ utils.mixin(jake, new (function () {
       // Create padding-string with calculated length
       padding = (new Array(maxTaskNameLength - p.length + 2)).join(' ');
 
-      descr = task.description
+      descr = task.description;
       if (descr) {
         descr = '\033[90m # ' + descr + '\033[39m \033[37m \033[39m';
         console.log('jake ' + name + padding + descr);
@@ -160,7 +161,7 @@ utils.mixin(jake, new (function () {
       , opts = {}
       , prereqs = [];
 
-      type = args.shift()
+      type = args.shift();
 
     // name, [deps], [action]
     // Name (string) + deps (array) format
@@ -173,7 +174,7 @@ utils.mixin(jake, new (function () {
     // name:deps, [action]
     // Legacy object-literal syntax, e.g.: {'name': ['depA', 'depB']}
     else {
-      obj = args.shift()
+      obj = args.shift();
       for (var p in obj) {
         prereqs = prereqs.concat(obj[p]);
         name = p;

--- a/lib/npm_publish_task.js
+++ b/lib/npm_publish_task.js
@@ -108,7 +108,7 @@ NpmPublishTask.prototype = new (function () {
           // New package-version
           pkg.version = version;
           // Commit-message
-          message = 'Version ' + version
+          message = 'Version ' + version;
 
           // Update package.json with the new version-info
           fs.writeFileSync(path, JSON.stringify(pkg, true, 2));
@@ -139,7 +139,7 @@ NpmPublishTask.prototype = new (function () {
 
       task('package', {async: true}, function () {
         var definePack = jake.Task['npm:definePackage']
-          , pack = jake.Task['package']
+          , pack = jake.Task.package
           , version = getPackageVersionNumber();
         // May have already been run
         definePack.reenable(true);
@@ -171,7 +171,7 @@ NpmPublishTask.prototype = new (function () {
       });
 
       task('cleanup', function () {
-        var clobber = jake.Task['clobber'];
+        var clobber = jake.Task.clobber;
         clobber.reenable(true);
         clobber.invoke();
         console.log('Cleaned up package');

--- a/lib/package_task.js
+++ b/lib/package_task.js
@@ -230,72 +230,74 @@ PackageTask.prototype = new (function () {
     desc('Remove the package');
     task('clobber', ['clobberPackage']);
 
+    var doCommand = function (p) {
+      var filename = path.resolve(self.packageDir + '/' + self.packageName() +
+                                  _compressOpts[p].ext);
+      compressTaskArr.push(filename);
+
+      file(filename, [packageDirPath], function () {
+        var cmd
+        , opts = _compressOpts[p]
+        // Directory to move to when doing the compression-task
+        // Changes in the case of zip for emulating -C option
+        , chdir = self.packageDir
+        // Save the current dir so it's possible to pop back up
+        // after compressing
+        , currDir = process.cwd();
+
+        cmd = self[opts.cmd + 'Command'];
+        cmd += ' -' + opts.flags;
+        if (opts.cmd == 'jar' && self.manifestFile) {
+          cmd += 'm';
+        }
+
+        // The name of the archive to create -- use full path
+        // so compression can be performed from a different dir
+        // if needed
+        cmd += ' ' + filename;
+
+        if (opts.cmd == 'jar' && self.manifestFile) {
+          cmd += ' ' + self.manifestFile;
+        }
+
+        // Where to perform the compression -- -C option isn't
+        // supported in zip, so actually do process.chdir for this
+        if (self.archiveChangeDir) {
+          if (opts.cmd == 'zip') {
+            chdir = path.join(chdir, self.archiveChangeDir);
+          }
+          else {
+            cmd += ' -C ' + self.archiveChangeDir;
+          }
+        }
+
+        // Where to stick the archive
+        if (self.archiveContentDir) {
+          cmd += ' ' + self.archiveContentDir;
+        }
+        else {
+          cmd += ' ' + self.packageName();
+        }
+
+        // Move into the desired dir (usually packageDir) to compress
+        // Return back up to the current dir after the exec
+        process.chdir(chdir);
+
+        exec(cmd, function (err, stdout, stderr) {
+          if (err) { throw err; }
+
+          // Return back up to the starting directory (see above,
+          // before exec)
+          process.chdir(currDir);
+
+          complete();
+        });
+      }, {async: true});
+    };
+
     for (var p in _compressOpts) {
       if (this['need' + p]) {
-        (function (p) {
-          var filename = path.resolve(self.packageDir + '/' + self.packageName() +
-              _compressOpts[p].ext);
-          compressTaskArr.push(filename);
-
-          file(filename, [packageDirPath], function () {
-            var cmd
-              , opts = _compressOpts[p]
-            // Directory to move to when doing the compression-task
-            // Changes in the case of zip for emulating -C option
-              , chdir = self.packageDir
-            // Save the current dir so it's possible to pop back up
-            // after compressing
-              , currDir = process.cwd();
-
-            cmd = self[opts.cmd + 'Command'];
-            cmd += ' -' + opts.flags;
-            if (opts.cmd == 'jar' && self.manifestFile) {
-              cmd += 'm';
-            }
-
-            // The name of the archive to create -- use full path
-            // so compression can be performed from a different dir
-            // if needed
-            cmd += ' ' + filename;
-
-            if (opts.cmd == 'jar' && self.manifestFile) {
-              cmd += ' ' + self.manifestFile;
-            }
-
-            // Where to perform the compression -- -C option isn't
-            // supported in zip, so actually do process.chdir for this
-            if (self.archiveChangeDir) {
-                if (opts.cmd == 'zip') {
-                    chdir = path.join(chdir, self.archiveChangeDir);
-                }
-                else {
-                    cmd += ' -C ' + self.archiveChangeDir;
-                }
-            }
-
-            // Where to stick the archive
-            if (self.archiveContentDir) {
-              cmd += ' ' + self.archiveContentDir;
-            }
-            else {
-              cmd += ' ' + self.packageName();
-            }
-
-            // Move into the desired dir (usually packageDir) to compress
-            // Return back up to the current dir after the exec
-            process.chdir(chdir);
-
-            exec(cmd, function (err, stdout, stderr) {
-              if (err) { throw err; }
-
-              // Return back up to the starting directory (see above,
-              // before exec)
-              process.chdir(currDir);
-
-              complete();
-            });
-          }, {async: true});
-        })(p);
+        doCommand(p);
       }
     }
 

--- a/lib/program.js
+++ b/lib/program.js
@@ -218,7 +218,7 @@ Program.prototype = new (function () {
 
     task('__root__', taskNames, function () {});
 
-    rootTask = jake.Task['__root__'];
+    rootTask = jake.Task.__root__;
     rootTask.once('complete', function () {
       jake.emit('complete');
     });

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -250,7 +250,7 @@ Rule.prototype = new (function () {
     action = function () {
       var task = this;
       self.action.apply(task, taskArgs);
-    }
+    };
 
     opts = this.opts;
 

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -190,7 +190,7 @@ TaskBase = new (function () {
 
   this.isNeeded = function () {
     if (this.done || typeof this.action != 'function') {
-      return false
+      return false;
     }
     return true;
   };

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -73,7 +73,7 @@ var parseArgs = function (argumentsObj) {
       cmds: cmds
     , opts: opts
     , callback: callback
-    }
+    };
 };
 
 /**
@@ -205,12 +205,12 @@ utils.mixin(Exec.prototype, new (function () {
           // Exit, handle err or run next
           sh.on('exit', function (code) {
             var msg;
-            if (code != 0) {
+            if (code !== 0) {
               msg = errData || 'Process exited with error.';
               msg = utils.string.trim(msg);
               self.emit('error', msg, code);
             }
-            if (code == 0 || !config.breakOnError) {
+            if (code === 0 || !config.breakOnError) {
               self.emit('cmdEnd', next);
               _run.call(self);
             }

--- a/test/exec.js
+++ b/test/exec.js
@@ -24,14 +24,17 @@ var tests = {
         }
       , incr = 0; // Increment with each event to check order
     assert.ok(ex instanceof jake.Exec);
+
+    var addListenerAndIncrement = function (p) {
+      ex.addListener(p, function () {
+        evts[p][1] = incr;
+        incr++;
+      });
+    };
+
     // Make sure basic events fire and fire in the right order
     for (var p in evts) {
-      (function (p) {
-        ex.addListener(p, function () {
-          evts[p][1] = incr;
-          incr++;
-        });
-      })(p);
+      addListenerAndIncrement(p);
     }
     ex.run();
     ex.addListener('end', function () {

--- a/test/file_task.js
+++ b/test/file_task.js
@@ -6,7 +6,7 @@ var assert = require('assert')
 
 var cleanUpAndNext = function (callback) {
   exec('rm -fr ./foo', function (err, stdout, stderr) {
-    if (err) { throw err }
+    if (err) { throw err; }
     if (stderr || stdout) {
       console.log (stderr || stdout);
     }

--- a/test/rule.js
+++ b/test/rule.js
@@ -8,7 +8,7 @@ var assert = require('assert')
 
 var cleanUpAndNext = function (callback) {
   exec('rm -fr ./foo ./tmp*', function (err, stdout, stderr) {
-    if (err) { throw err }
+    if (err) { throw err; }
     if (stderr || stdout) {
       console.log (stderr || stdout);
     }


### PR DESCRIPTION
I refactored the code to clear away more of the JSHint warnings.

JSHint before:

```
$ jshint .
lib\file_list.js: line 174, col 8, Missing semicolon.

lib\jake.js: line 78, col 31, Missing semicolon.
lib\jake.js: line 134, col 16, 'p' is already defined.
lib\jake.js: line 145, col 31, Missing semicolon.
lib\jake.js: line 163, col 26, Missing semicolon.
lib\jake.js: line 176, col 25, Missing semicolon.

lib\npm_publish_task.js: line 111, col 41, Missing semicolon.
lib\npm_publish_task.js: line 142, col 29, ['package'] is better written in dot notation.
lib\npm_publish_task.js: line 174, col 32, ['clobber'] is better written in dot notation.

lib\package_task.js: line 298, col 10, Don't make functions within a loop.

lib\parseargs.js: line 55, col 53, Use '===' to compare with '0'.
lib\parseargs.js: line 79, col 28, Use '===' to compare with '0'.

lib\program.js: line 221, col 25, ['__root__'] is better written in dot notation.

lib\rule.js: line 253, col 6, Missing semicolon.

lib\task\task.js: line 193, col 19, Missing semicolon.

lib\utils\index.js: line 76, col 6, Missing semicolon.
lib\utils\index.js: line 208, col 22, Use '!==' to compare with '0'.
lib\utils\index.js: line 213, col 22, Use '===' to compare with '0'.

test\exec.js: line 34, col 8, Don't make functions within a loop.

test\file_task.js: line 9, col 25, Missing semicolon.

test\parseargs.js: line 122, col 69, Duplicate key 'test --trace does not expect a value, -f does (throw howdy away)'.

test\rule.js: line 11, col 25, Missing semicolon.

22 errors
```

JSHint after:

```
$ jshint .
lib\parseargs.js: line 55, col 53, Use '===' to compare with '0'.
lib\parseargs.js: line 79, col 28, Use '===' to compare with '0'.

test\parseargs.js: line 122, col 69, Duplicate key 'test --trace does not expect a value, -f does (throw howdy away)'.

3 errors
```

The warnings for `lib/parseargs.js` are easy to resolve, but I thought I'd suggest [optimist](https://github.com/mde/jake/issues/193) instead.
