### PR TITLE
Make sure to flush stdout and stderr before exit

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -133,7 +133,11 @@ Program.prototype = new (function () {
         utils.logger.error(err.message);
       }
     }
-    process.exit(jake.errorCode || 1);
+    process.stdout.write('', function() {
+      process.stderr.write('', function() {
+        process.exit(jake.errorCode || 1);
+      });
+    });
   };
 
   this.parseArgs = function (args) {
@@ -231,7 +235,11 @@ Program.prototype = new (function () {
 
 die = function (msg) {
   console.log(msg);
-  process.exit();
+  process.stdout.write('', function() {
+    process.stderr.write('', function() {
+      process.exit();
+	});
+  });
 };
 
 module.exports.Program = Program;


### PR DESCRIPTION
When running `jake` with it's output piped, the last lines of output are lost on exit. Unfortunately this is where the interesting part is when the build fails (error message and stack trace).

The reason is that when pipe make the output not blocking. Here is the corresponding [doc](http://nodejs.org/api/process.html#process_process_stdout):

> process.stderr and process.stdout are unlike other streams in Node in that writes to them are usually blocking. They are blocking in the case that they refer to regular files or TTY file descriptors. In the case they refer to pipes, they are non-blocking like other streams.

Here is a simple program that highlight the problem:

``` js
console.log('testing');
console.log('');
console.log('');
console.log('bye');

if (process.argv[2] === 'wait') {
    process.stdout.write('', function() {
        process.stderr.write('', function() {
            process.exit();
        });
    });
} else {
    process.exit();
}
```

And the output:

``` sh
$ node test.js
testing


bye

$ node test.js | cat
testing

$ node test.js wait | cat
testing


bye
```

Regards
