### PR TITLE
Fix package/publish problems on Windows

### DIFF
--- a/lib/npm_publish_task.js
+++ b/lib/npm_publish_task.js
@@ -145,11 +145,17 @@ NpmPublishTask.prototype = new (function () {
           , 'git push --tags'
           ];
 
+          var execOpts = {};
+          if (process.platform == 'win32') {
+            // Windows won't like the quotes in our cmdline
+            execOpts.windowsVerbatimArguments = true;
+          }
+
           jake.exec(cmds, function () {
             var version = getPackageVersionNumber();
             console.log('Bumped version number to v' + version + '.');
             complete();
-          });
+          }, execOpts);
         });
       });
 

--- a/lib/package_task.js
+++ b/lib/package_task.js
@@ -233,6 +233,13 @@ PackageTask.prototype = new (function () {
     var doCommand = function (p) {
       var filename = path.resolve(self.packageDir + '/' + self.packageName() +
                                   _compressOpts[p].ext);
+      if (process.platform == 'win32') {
+          // Windows full path may have drive letter, which is going to cause
+          // namespace problems, so strip it.
+          if (filename.length > 2 && filename[1] == ':') {
+            filename = filename.substr(2);
+          }
+      }
       compressTaskArr.push(filename);
 
       file(filename, [packageDirPath], function () {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -94,6 +94,8 @@ utils.mixin(utils, new (function () {
       @param {Boolean} [opts.printStderr=false] Print stderr from each command
       @param {Boolean} [opts.breakOnError=true] Stop further execution on
       the first error.
+      @param {Boolean} [opts.windowsVerbatimArguments=false] Don't translate
+      arguments on Windows.
     @param {Function} [callback] Callback to run after executing  the
     commands
 
@@ -171,12 +173,16 @@ utils.mixin(Exec.prototype, new (function () {
 
         // Keep running as long as there are commands in the array
         if (next) {
+          var spawnOpts = {};
           this.emit('cmdStart', next);
 
           // Ganking part of Node's child_process.exec to get cmdline args parsed
           if (process.platform == 'win32') {
             cmd = 'cmd';
             args = ['/c', next];
+            if (config.windowsVerbatimArguments) {
+              spawnOpts.windowsVerbatimArguments = true;
+            }
           }
           else {
             cmd = '/bin/sh';
@@ -184,10 +190,12 @@ utils.mixin(Exec.prototype, new (function () {
           }
 
           if (config.interactive) {
-            sh = spawn(cmd, args, { stdio: 'inherit' });
+            spawnOpts.stdio = 'inherit';
+            sh = spawn(cmd, args, spawnOpts);
           }
           else {
-            sh = spawn(cmd, args, { stdio: [process.stdin, 'pipe', 'pipe'] });
+            spawnOpts.stdio = [process.stdin, 'pipe', 'pipe'];
+            sh = spawn(cmd, args, spawnOpts);
             // Out
             sh.stdout.on('data', function (data) {
               self.emit('stdout', data);


### PR DESCRIPTION
There are two problems with packaging/publishing tasks on Windows:
- Without the windowsVerbatimArguments flag, spawn strips off the quotes
  from the arguments, causing bad command lines for the git commands in
  npmPublish.
- The publish task needs to strip off the drive letter from the full
  path, or else jake will interpret it as a namespace and fail to find the
  file task.
