### PR TITLE
Fixed regression introduced by b0fcf1c

### DIFF
--- a/lib/jake.js
+++ b/lib/jake.js
@@ -310,7 +310,10 @@ utils.mixin(jake, new (function () {
     else {
       opts = program.opts;
       // Load Jakefile and jakelibdir files
-      if(!loader.loadFile(opts.jakefile) && !loader.loadDirectory(opts.jakelibdir)) {
+      var jakefileLoaded = loader.loadFile(opts.jakefile);
+      var jakelibdirLoaded = loader.loadDirectory(opts.jakelibdir);
+
+      if(!jakefileLoaded && !jakelibdirLoaded) {
         fail('No Jakefile. Specify a valid path with -f/--jakefile, ' +
             'or place one in the current directory.');
       }


### PR DESCRIPTION
That commit broke the ability to load both jakefile and jakelibdir. If `loader.loadFile(opts.jakefile)` returns true, then `loader.loadDirectory(opts.jakelibdir)` doesn't get called.

Please be more cautious in accepting broken pull requests...
