### PR TITLE
Initialize CoffeeScript >= 1.7.0 for both directory and file loads

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -31,11 +31,16 @@ Loader = function () {
 
   var _requireCoffee = function () {
         try {
-          return require('coffee-script');
+          var cs = require('coffee-script');
+          // Ensure we support CoffeeScript versions older than 1.7.0
+          if (typeof cs.register == 'function') {
+            cs.register();
+          }
         }
         catch (e) {
           fail('CoffeeScript is missing! Try `npm install coffee-script`');
         }
+        return(cs);
       };
 
   this.loadFile = function (file) {
@@ -87,10 +92,6 @@ Loader = function () {
         if (JAKEFILE_PAT.test(filePath)) {
           if (/\.coffee$/.test(filePath)) {
             CoffeeScript = _requireCoffee();
-            // Ensure we support CoffeeScript versions older than 1.7.0
-            if (typeof CoffeeScript.register == 'function') {
-              CoffeeScript.register();      
-            }
           }
           require(path.join(dirname, filePath));
         }


### PR DESCRIPTION
Commits b9e455b3b9bea293e0beb1d850df9dc1587148b5,
df5359bb24fd013043aa05c10264e9267e9ea5fb, and
55093f141cd61a2481c6d52b11b07993613ae17d introduced changes to register the
CoffeeScript compiler as required by CS >= 1.7.0.  Unfortunately the
registration only handled directory loads and not file loads.  This commit
centralizes the compiler registration in the _requireCoffee function so
that it is always called.  This problem was breaking Jake with Jake 0.7.9,
CoffeeScript 1.7.1, and Node 0.8.26.
