### PR TITLE
Use process.nextTick instead of setTimeout

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -221,9 +221,9 @@ TaskBase = new (function () {
     var self = this;
     this._currentPrereqIndex++;
     if (this._currentPrereqIndex < this.prereqs.length) {
-      setTimeout(function () {
+      process.nextTick(function () {
         self.nextPrereq();
-      }, 0);
+      });
     }
     else {
       this.run();
@@ -251,16 +251,14 @@ TaskBase = new (function () {
 
           val.then(
             function(result) {
-              setTimeout(function() {
+              process.nextTick(function() {
                   complete(result);
-                },
-                0);
+                });
             },
             function(err) {
-              setTimeout(function() {
+              process.nextTick(function() {
                   fail(err);
-                },
-                0);
+                });
             });
         }
       }


### PR DESCRIPTION
setTimeout in node have weird behavior when debugging jake with node-inspector. The time you spent in paused state added to time timer counts until actual emit, so execution of actual code halt for a long time (actually there is node timer code executed). process.nextTick does the same thing here, delaying execution to the next tick, but it have no problems with timers.
