### PR TITLE
Node complaining on process.nextTick

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -221,7 +221,7 @@ TaskBase = new (function () {
     var self = this;
     this._currentPrereqIndex++;
     if (this._currentPrereqIndex < this.prereqs.length) {
-      process.nextTick(function () {
+      setImmediate(function () {
         self.nextPrereq();
       });
     }
@@ -251,12 +251,12 @@ TaskBase = new (function () {
 
           val.then(
             function(result) {
-              process.nextTick(function() {
+              setImmediate(function() {
                   complete(result);
                 });
             },
             function(err) {
-              process.nextTick(function() {
+              setImmediate(function() {
                   fail(err);
                 });
             });


### PR DESCRIPTION
(node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
