### PR TITLE
bash auto completion

### DIFF
--- a/bin/auto_complete.js
+++ b/bin/auto_complete.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+var FS = require('fs');
+var jake = require('../lib/jake.js');
+
+jake.program.internalOpts([
+  { full: 'autocomplete'
+  , preempts: false
+  , expectValue: false
+  }
+, { full: 'autocomplete-cur'
+  , preempts: false
+  , expectValue: true
+  }
+, { full: 'autocomplete-prev'
+  , preempts: false
+  , expectValue: true
+  }
+]);
+
+var autoArgs = ['--autocomplete', '--autocomplete-cur', process.argv[2], '--autocomplete-prev', process.argv[3]];
+var compArgs = process.env.COMP_LINE.split(' ');
+
+jake.run.apply(jake, autoArgs.concat(compArgs));

--- a/bin/bash_completion.sh
+++ b/bin/bash_completion.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# http://stackoverflow.com/a/246128
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+JAKE_BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+# http://stackoverflow.com/a/12495480
+# http://stackoverflow.com/a/28647824
+_auto_jake()
+{
+    local cur
+    local -a COMPGEN=()
+    _get_comp_words_by_ref -n : -c cur
+    
+    # run auto-completions in jake via our auto_complete.js wrapper
+    local -a auto_complete_info=( $(export COMP_LINE="${COMP_LINE}" && ${JAKE_BIN_DIR}/auto_complete.js "$cur" "${3}") )
+    # check reply flag
+    local reply_flag="${auto_complete_info[0]}"
+    if [[ "${reply_flag}" == "no-complete" ]]; then
+        return 1
+    fi
+    local auto_completions=("${auto_complete_info[@]:1}")
+    COMPGEN=( $(compgen -W "${auto_completions[*]}" -- "$cur") )
+    COMPREPLY=( "${COMPGEN[@]}" )
+    
+    __ltrim_colon_completions "$cur"
+    
+    # do we need another space??
+    if [[ "${reply_flag}" == "yes-space" ]]; then
+        COMPREPLY=( "${COMPGEN[@]}" " " )
+    fi
+    
+    return 0
+} 
+
+complete -o default -F _auto_jake jake

--- a/lib/jake.js
+++ b/lib/jake.js
@@ -311,11 +311,16 @@ utils.mixin(jake, new (function () {
     }
     else {
       opts = program.opts;
+      // jakefile flag set but no jakefile yet
+      if (opts.autocomplete && opts.jakefile === true) {
+        process.stdout.write('no-complete');
+        return;
+      }
       // Load Jakefile and jakelibdir files
       var jakefileLoaded = loader.loadFile(opts.jakefile);
       var jakelibdirLoaded = loader.loadDirectory(opts.jakelibdir);
 
-      if(!jakefileLoaded && !jakelibdirLoaded) {
+      if(!jakefileLoaded && !jakelibdirLoaded && !opts.autocomplete) {
         fail('No Jakefile. Specify a valid path with -f/--jakefile, ' +
             'or place one in the current directory.');
       }

--- a/lib/program.js
+++ b/lib/program.js
@@ -164,6 +164,50 @@ Program.prototype = new (function () {
     utils.mixin(this.opts, opts);
   };
 
+  this.internalOpts = function (options) {
+    optsReg = optsReg.concat(options);
+  };
+  
+  this.autocompletions = function (cur) {
+    var p, i, task
+    , commonPrefix = ''
+    , matches = [];
+
+    for (p in jake.Task) {
+      task = jake.Task[p];
+      if (
+        'fullName' in task
+          && (
+            // if empty string, program converts to true
+            cur === true ||
+            task.fullName.indexOf(cur) === 0
+          )
+      ) {
+        if (matches.length === 0) {
+          commonPrefix = task.fullName;
+        }
+        else {
+          for (i = commonPrefix.length; i > -1; --i) {
+            commonPrefix = commonPrefix.substr(0, i);
+            if (task.fullName.indexOf(commonPrefix) === 0) {
+              break;
+            }
+          }
+        }
+        matches.push(task.fullName);
+      }
+    }
+
+    if (matches.length > 1 && commonPrefix === cur) {
+      matches.unshift('yes-space');
+    }
+    else {
+      matches.unshift('no-space');
+    }
+
+    process.stdout.write(matches.join(' '));
+  };
+  
   this.setTaskNames = function (names) {
     if (names && !Array.isArray(names)) {
       throw new Error('Task names must be an array');
@@ -211,6 +255,9 @@ Program.prototype = new (function () {
       , dirname
       , opts = this.opts;
 
+    if (opts.autocomplete) {
+      return this.autocompletions(opts['autocomplete-cur'], opts['autocomplete-prev']);
+    }
     // Run with `jake -T`, just show descriptions
     if (opts.tasks) {
       return jake.showAllTaskDescriptions(opts.tasks);

--- a/test/auto_complete_test_jakefile
+++ b/test/auto_complete_test_jakefile
@@ -1,0 +1,18 @@
+
+desc('This is the default task.');
+task('default', function () {
+  console.log('This is the default task.');
+});
+
+namespace('foo', function () {
+  desc('This the foo:bar task');
+  task('bar', function () {
+    console.log('doing foo:bar task');
+  });
+
+  desc('This the foo:baz task');
+  task('baz', ['default', 'foo:bar'], function () {
+    console.log('doing foo:baz task');
+  });
+
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -32,7 +32,8 @@ var helpers = new (function () {
     }
 
     cmd += ' --trace';
-    exec(cmd, function (err, stdout, stderr) {
+    var execOpts = opts.execOpts ? opts.execOpts : {};
+    exec(cmd, execOpts, function (err, stdout, stderr) {
       var out = helpers.trim(stdout);
       if (err) {
         if (opts.breakOnError === false) {

--- a/test/task_base.js
+++ b/test/task_base.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
-  , h = require('./helpers');
+  , h = require('./helpers')
+  , utils = require('utilities');
 
 var tests = {
 
@@ -63,6 +64,42 @@ var tests = {
       assert.equal(args[1], 'bar');
       assert.equal(env.foo, 'bar');
       assert.equal(env.baz, 'qux');
+      next();
+    });
+  }
+
+, 'test single auto completion': function (next) {
+    var args = ['-f', './auto_complete_test_jakefile', 'd']
+      , opts = _getAutoCompleteOpts(args);
+    h.exec('../bin/auto_complete.js '+_getAutoCompleteExecArgs(args), opts, function (out) {
+      assert.equal('no-space default', out);
+      next();
+    });
+  }
+
+, 'test multiple auto completion': function (next) {
+    var args = ['-f', './auto_complete_test_jakefile', 'foo:ba']
+      , opts = _getAutoCompleteOpts(args);
+    h.exec('../bin/auto_complete.js '+_getAutoCompleteExecArgs(args), opts, function (out) {
+      assert.equal('yes-space foo:bar foo:baz', out);
+      next();
+    });
+  }
+
+, 'test file argument auto completion': function (next) {
+    var args = ['-f']
+      , opts = _getAutoCompleteOpts(args);
+    h.exec('../bin/auto_complete.js '+_getAutoCompleteExecArgs(args), opts, function (out) {
+      assert.equal('no-complete', out);
+      next();
+    });
+  }
+
+, 'test no completions auto completion': function (next) {
+    var args = ['-f', './auto_complete_test_jakefile', 'no-such-completion']
+      , opts = _getAutoCompleteOpts(args);
+    h.exec('../bin/auto_complete.js '+_getAutoCompleteExecArgs(args), opts, function (out) {
+      assert.equal('no-space', out);
       next();
     });
   }
@@ -160,6 +197,22 @@ var tests = {
   }
 
 };
+
+function _getAutoCompleteOpts(args) {
+  return {
+    execOpts: {
+      env: utils.object.merge({
+        COMP_LINE: 'node jake ' + args.join(' ')
+      }, process.env)
+    }
+  };
+}
+
+function _getAutoCompleteExecArgs(args) {
+  var nArgs = args.length;
+  return args[nArgs - 1]+' '+(nArgs > 1 ? args[nArgs - 2] : '');
+}
+
 
 module.exports = tests;
 


### PR DESCRIPTION
An attempt at bash auto completion. Some notes:
- The basic idea is to run the actual Jakefile with some new flags to generate completions (ie, no new parsing code)
- I added an `internalOpts` function to `program.js` so we can tell jake in the `auto_complete.js` wrapper what we are doing
- I don't know anything about auto completion in other shells/OSes (I'm on a debian based system), but I tried to do as much in javascript as possible with the idea that the code could be re-used in other environments. I actually think I may have gone too far here, as some quirks of bash are handled that I doubt would be applicable elsewhere
- Things were complicated quite a bit by needing to support ':' in bash completion. There are some links to stackoverflow answers that helped in `bash_completion.sh`
- Things also seem to be working if a project does not use a default Jakefile. At first, completions will be default bash completions, but as soon as we've got `-f path/to/custom-jakefile`, it will start using targets from the custom jakefile for completions
- ~~I did not add any tests, however I ran the current test suite and it appears nothing is broken. To test for now, just source `bin/bash_completion.js` and test with an executable `jake` (ie if you have it globally installed, or you have another project that uses jake)~~ EDIT: test included in task_base.js
- not using COMP_CWORD or COMP_POINT
- Looks like the README is mostly just a link to the docs. I have not looked into updating those. Basically can say something like https://github.com/creationix/nvm/blob/master/README.markdown#bash-completion

Let me know what you guys think!
