### PR TITLE
Package task fails with too many files

### DIFF
--- a/lib/package_task.js
+++ b/lib/package_task.js
@@ -211,17 +211,17 @@ PackageTask.prototype = new (function () {
   var _compressOpts = {
         Tar: {
           ext: '.tgz'
-        , flags: 'cvzf'
+        , flags: 'czf'
         , cmd: 'tar'
         }
       , TarGz: {
           ext: '.tar.gz'
-        , flags: 'cvzf'
+        , flags: 'czf'
         , cmd: 'tar'
         }
       , TarBz2: {
           ext: '.tar.bz2'
-        , flags: 'cvjf'
+        , flags: 'cjf'
         , cmd: 'tar'
         }
       , Jar: {
@@ -231,7 +231,7 @@ PackageTask.prototype = new (function () {
         }
       , Zip: {
           ext: '.zip'
-        , flags: 'r'
+        , flags: 'qr'
         , cmd: 'zip'
         }
       };


### PR DESCRIPTION
This happens because the compress commands called via exec are
using verbose output which can then exceed the max size for the
output buffer, resulting in a "Error: stdout maxBuffer exceeded."
error. The output is never exposed anywhere, so there's no point
in using verbose output for these commands.