### PR TITLE
PackageTask.archiveNoBaseDir with tar formats fails

### DIFF
--- a/lib/package_task.js
+++ b/lib/package_task.js
@@ -279,7 +279,7 @@ PackageTask.prototype = new (function () {
 
         if (self.archiveNoBaseDir) {
           archiveChangeDir = self.packageName();
-          archiveContentDir = '.* -x "../*"';
+          archiveContentDir = '.';
         }
         else {
           archiveChangeDir = self.archiveChangeDir;


### PR DESCRIPTION
This results in an error such as the following:
Error: Command failed: tar: ../build-1.0.0.tgz: Can't add archive to itself
tar: -x: Cannot stat: No such file or directory
tar: ../*: Cannot stat: No such file or directory

The current selector of ".*" was used because the previous selector,
"*", was not including hidden files. However, the * expands the files
from . and ends up including the parent (..) directory, hence the
attempt to exclude it (which works for zip, but is incorrect for
tar commands). However, simply using "." as the file selector yields
the desired results across compression programs.