### PR TITLE
-T ignores -f unless -f is placed first

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -48,12 +48,12 @@ optsReg = [
   }
 , { full: 'tasks'
   , abbr: 'T'
-  , preempts: true
+  , preempts: false
   }
 // Alias ls
 , { full: 'tasks'
   , abbr: 'ls'
-  , preempts: true
+  , preempts: false
   }
 , { full: 'trace'
   , abbr: 't'


### PR DESCRIPTION
Fixes #276. This is because -T/--tasks/-ls is defined as a command that
preempts, causing it to not take in any args. However, it does not need
to be preemptive because the --task option short circuts Program.run on
line 215, currently
(https://github.com/jakejs/jake/blob/6d47c7f8461f17c2c2a53455a098c0449253bb36/lib/program.js#L215),
and in doing so applies arguments such as -f.