### PR TITLE
Fix watch task's default exclude patterns to avoid "RegExp too big" error...

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 Documentation site at [http://jakejs.com](http://jakejs.com/)
 
+### Contributing
+1. [Install node](http://nodejs.org/#download).
+2. Clone this repository `$ git clone git@github.com:jakejs/jake.git`.
+3. Install dependencies `$ npm install`.
+4. Run tests with `$ npm test`.
+5. Start Hacking!
+
 ### License
 
 Licensed under the Apache License, Version 2.0

--- a/lib/watch_task.js
+++ b/lib/watch_task.js
@@ -92,9 +92,6 @@ WatchTask.DEFAULT_EXCLUDE_FILES = [];
 if (fs.existsSync('node_modules')) {
   WatchTask.DEFAULT_EXCLUDE_FILES.push('node_modules/**');
 }
-if (fs.existsSync('.git')) {
-  WatchTask.DEFAULT_EXCLUDE_FILES.push('.git/**');
-}
 
 exports.WatchTask = WatchTask;
 

--- a/lib/watch_task.js
+++ b/lib/watch_task.js
@@ -90,7 +90,7 @@ WatchTask.DEFAULT_INCLUDE_FILES = [
 
 WatchTask.DEFAULT_EXCLUDE_FILES = [];
 if (fs.existsSync('node_modules')) {
-  WatchTask.DEFAULT_EXCLUDE_FILES.push('node_modules/**');
+  WatchTask.DEFAULT_EXCLUDE_FILES.push(/(^|[\/\\])node_modules([\/\\]|$)/);
 }
 
 exports.WatchTask = WatchTask;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "jake": "./bin/cli.js"
   },
   "main": "./lib/jake.js",
+  "scripts": {
+    "test": "./bin/cli.js test"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/mde/jake.git"


### PR DESCRIPTION
background: https://github.com/jakejs/jake/issues/304

all tests pass! buuut, i didn't see any for the watch task specifically. so, not a super-high level of confidence but this _did_ fix the "RegExp too big" for me running locally via `npm link`

i'll think a bit more about how we might test things here. otherwise, this seem legit?