### PR TITLE
Task arguments couldnt' contain equal symbol

### DIFF
--- a/lib/parseargs.js
+++ b/lib/parseargs.js
@@ -111,15 +111,16 @@ parseargs.Parser.prototype = new function () {
     if (!preempt) {
       // Parse out any env-vars and task-name
       while (!!(cmd = cmds.pop())) {
+        // Split up env args
         cmdItems = cmd.split('=');
-        if (cmdItems.length > 1) {
+        // Don't confuse task arguments with task args that contain a "="
+        if (cmdItems.length > 1) {//} && cmdItems[0].indexOf('[') === -1) {
           envVars[cmdItems[0]] = cmdItems[1];
         }
         else {
           taskNames.push(cmd);
         }
       }
-
     }
 
     return {


### PR DESCRIPTION
Fixes #311 

This still needs unit tests, but I want to make sure the approach doesn't miss some other edge case. However, this will break scripts that have an env variable with a [ in the name, unfortunately. I'm not sure if there's a way around that.

We could enforce that env names adhere to the POSIX standard: `a word consisting solely of underscores, digits, and alphabetics from the portable character set. The first character of a name is not a digit`
