### PR TITLE
Add app global vars

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -334,6 +334,42 @@ command. You can do this by adding this line to your `.zshrc` file :
 
     alias jake="noglob jake"
 
+### Setup jake program global settings
+
+Jake supports the ability to setup global settings (to program) and later use this settings in tasks.
+
+This is may be useful when tasks was split to some files in `jakelib` but must use some settings, f.e. path to directory:
+
+```javascript
+// At Jakefile
+jake.program.setAppVars('libDir', '../foo/lib');
+jake.program.setAppVars({'srcDir': '../bazz/src', 'binDir': '../foo/bin'});
+```
+
+And later use it:
+
+```javascript
+// At  jakelib/common.jake
+desc('Clear lib.');
+task('clearLib', function () {
+  var libDir = jake.program.appVars.libDir;
+  // Do something with libDir value
+});
+```
+
+```javascript
+// At  jakelib/build.jake
+desc('Build lib.');
+task('buildLib', function () {
+  var libDir = jake.program.appVars.libDir,
+      srcDir = jake.program.appVars.srcDir,
+      binDir = jake.program.appVars.binDir;
+  // Do something with libDir value
+});
+```
+
+With application variables it will be easy to have one source of settings to rule it.
+
 ### Cleanup after all tasks run, jake 'complete' event
 
 The base 'jake' object is an EventEmitter, and fires a 'start' event before

--- a/lib/program.js
+++ b/lib/program.js
@@ -113,6 +113,7 @@ Program = function () {
   this.taskNames = null;
   this.taskArgs = null;
   this.envVars = null;
+  this.appVars = {};
 };
 
 Program.prototype = new (function () {
@@ -173,6 +174,23 @@ Program.prototype = new (function () {
 
   this.setEnvVars = function (vars) {
     this.envVars = vars || null;
+  };
+
+  // support both setAppVars(object) and setAppVars(key, value)
+  this.setAppVars = function (key, value) {
+    var newObject = {};
+    
+    if(typeof(key) === 'string'){
+      if(typeof(value) === 'undefined'){
+        throw new Error('Void value detected, halt!');
+      } else {
+        newObject[key] = value;
+      }
+    } else {
+      newObject = key;
+    }
+
+    this.appVars = utils.mixin({}, this.appVars, newObject);
   };
 
   this.firstPreemptiveOption = function () {

--- a/test/Jakefile
+++ b/test/Jakefile
@@ -39,6 +39,17 @@ task('argsEnvVars', function () {
   console.log(JSON.stringify(res));
 });
 
+desc('Use app vars.');
+task('appVars', function () {
+  var res;
+  jake.program.setAppVars('foo', 'bar');
+  jake.program.setAppVars({baz : 'qux'});
+  res = {
+    appVars: jake.program.appVars
+  };
+  console.log(JSON.stringify(res));
+});
+
 namespace('foo', function () {
   desc('The foo:bar task.');
   task('bar', function () {

--- a/test/task_base.js
+++ b/test/task_base.js
@@ -67,6 +67,16 @@ var tests = {
     });
   }
 
+, 'test using app vars': function (next) {
+    h.exec('../bin/cli.js appVars', function (out) {
+      var parsed = h.parse(out)
+        , appVars = parsed.appVars;
+      assert.equal(appVars.foo, 'bar');
+      assert.equal(appVars.baz, 'qux');
+      next();
+    });
+  }
+
 , 'test a simple prereq': function (next) {
     h.exec('../bin/cli.js foo:baz', function (out) {
       assert.equal('foo:bar task\nfoo:baz task', out);


### PR DESCRIPTION
I`m add ability to set global config in main Jakefile and use it in separated tasks in jakelib files.

We are use it for directory paths, to keep all project config in one place and have small tasks without hardcoding.