### PR TITLE
improve packageTask api

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -354,7 +354,6 @@ var api = new (function () {
   function createApi(jakeTaskConstructorGetter) {
     return function() {
       var jakeTaskConstructor = jakeTaskConstructorGetter();
-      if (!jakeTaskConstructor) console.error("INVALID TASK CTOR");
 
       var ctor = function () {}
         , t;

--- a/lib/api.js
+++ b/lib/api.js
@@ -351,9 +351,21 @@ var api = new (function () {
     }
   };
 
-  this.packageTask = function (name, version, definition) {
-    return new jake.PackageTask(name, version, definition);
-  };
+  function createApi(jakeTaskConstructorGetter) {
+    return function() {
+      var jakeTaskConstructor = jakeTaskConstructorGetter();
+      if (!jakeTaskConstructor) console.error("INVALID TASK CTOR");
+
+      var ctor = function () {}
+        , t;
+      ctor.prototype = jakeTaskConstructor.prototype;
+      t = new ctor();
+      jakeTaskConstructor.apply(t, arguments);
+      return t;
+    };
+  }
+
+  this.packageTask = createApi(function() { return jake.PackageTask;});
 
   this.publishTask = function (name, prereqs, opts, definition) {
     return new jake.PublishTask(name, prereqs, opts, definition);
@@ -368,14 +380,7 @@ var api = new (function () {
     return new jake.WatchTask(name, taskNames, definition);
   };
 
-  this.testTask = function () {
-    var ctor = function () {}
-      , t;
-    ctor.prototype = jake.TestTask.prototype;
-    t = new ctor();
-    jake.TestTask.apply(t, arguments);
-    return t;
-  };
+  this.testTask = createApi(function() { return jake.TestTask;});
 
 })();
 


### PR DESCRIPTION
If the author likes the new createApi function, it can be used for other api as well. The benefit here is that the actual api is then only defined by the task constructor in one place.

I had also earlier opened an issue for packageTask not getting the prereqs. This would be the solution to that.

Thanks. 