### PR TITLE
322 - Upgrade minimatch to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "preferGlobal": true,
   "dependencies": {
     "filelist": "0.0.x",
-    "minimatch": "0.2.x",
+    "minimatch": "3.x",
     "chalk": "0.4.x",
     "utilities": "1.0.x",
     "async": "0.9.x"


### PR DESCRIPTION
Upon installing the older version of minimatch, npm would emit the
following error:
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue

Addresses issue #322 