### PR TITLE
Feature/rules multi sources

### DIFF
--- a/lib/rule.js
+++ b/lib/rule.js
@@ -236,7 +236,6 @@ Rule.prototype = new (function () {
       , source
       , action
       , opts
-      , prereqs
       , parts
       , valid
       , src
@@ -244,26 +243,51 @@ Rule.prototype = new (function () {
       , createdTask
       , name = Task.getBaseTaskName(fullName)
       , nsPath = Task.getBaseNamespacePath(fullName)
-      , ns = this.ns.resolveNamespace(nsPath);
+      , ns = this.ns.resolveNamespace(nsPath)
+      , prereqs = this.prereqs.slice(); // Get a copy to work with
 
     pattern = this.pattern;
     source = this.source;
 
-    if (typeof source == 'string') {
-      src = Matcher.getSource(name, pattern, source);
-    }
-    else {
-      src = source(name);
-    }
+		if (typeof source == 'function') { 
+			// replace source function with returned value.
+			source = source(name);
+		}
 
     // TODO: Write a utility function that appends a
     // taskname to a namespace path
-    src = nsPath.split(':').filter(function (item) {
-      return !!item;
-    }).concat(src).join(':');
+		var completeNamespace = function(s){
+			return nsPath.split(':').filter(function (item) {
+				return !!item;
+			}).concat(s).join(':');
+		};
+
+    if (source instanceof Array) {
+			// Rule has multiple sources.  Find them all:
+			src = [];
+			source.forEach(function(srcName){
+				src.push(completeNamespace( Matcher.getSource(name, pattern, srcName) ));
+			});
+			prereqs = prereqs.concat(src);
+		} 
+		else if (typeof source == 'string') {
+      src = completeNamespace( Matcher.getSource(name, pattern, source) );
+			prereqs.unshift(src);
+    }
+    else {
+			// wtf?
+			debugger;
+			throw new Error("Can't parse rule source.");
+    }
+
+    // // TODO: Write a utility function that appends a
+    // // taskname to a namespace path
+    // src = nsPath.split(':').filter(function (item) {
+    //   return !!item;
+    // }).concat(src).join(':');
 
     // Generate the prerequisite for the matching task.
-    //    It is the original prerequisites plus the prerequisite
+    //    It is the original prerequisites plus the prerequisite/prerequisites
     //    representing source file, i.e.,
     //
     //      rule( '%.o', '%.c', ['some.h'] ...
@@ -271,8 +295,6 @@ Rule.prototype = new (function () {
     //    If the objective is main.o, then new task should be
     //
     //      file( 'main.o', ['main.c', 'some.h' ] ...
-    prereqs = this.prereqs.slice(); // Get a copy to work with
-    prereqs.unshift(src);
 
     // Prereq should be:
     // 1. an existing task
@@ -307,7 +329,14 @@ Rule.prototype = new (function () {
       tNs = jake.currentNamespace;
       jake.currentNamespace = ns;
       createdTask = jake.createTask('file', name, prereqs, action, opts);
-      createdTask.source = src.split(':').pop();
+			if (src instanceof Array) {
+				createdTask.source = [];
+				src.forEach(function(s){
+					createdTask.source.push(s.split(':').pop());
+				});
+			} else { 
+				createdTask.source = src.split(':').pop();
+			}
       jake.currentNamespace = tNs;
 
       return createdTask;

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -249,45 +249,64 @@ Rule.prototype = new (function () {
     pattern = this.pattern;
     source = this.source;
 
-		if (typeof source == 'function') { 
-			// replace source function with returned value.
-			source = source(name);
-		}
-
     // TODO: Write a utility function that appends a
     // taskname to a namespace path
-		var completeNamespace = function(s){
-			return nsPath.split(':').filter(function (item) {
-				return !!item;
-			}).concat(s).join(':');
-		};
+    var completeNamespace = function(s){
+      return nsPath.split(':').filter(function (item) {
+        return !!item;
+      }).concat(s).join(':');
+    };
 
-    if (source instanceof Array) {
-			// Rule has multiple sources.  Find them all:
-			src = [];
-			source.forEach(function(srcName){
-				src.push(completeNamespace( Matcher.getSource(name, pattern, srcName) ));
-			});
-			prereqs = prereqs.concat(src);
-		} 
-		else if (typeof source == 'string') {
+    // Deal with the various things the source argument can be:
+    // 1: A function
+    if (typeof source == 'function') { 
+      source = source(name);
+
+      if (source instanceof Array) {
+        // It's a function that returns an array of sources (strings)
+        src = [];
+        source.forEach(function(srcName){
+          src.push(completeNamespace( srcName) );
+        });
+        prereqs = prereqs.concat(src);
+      } 
+
+      else if (typeof source == 'string') {
+        // It's a function that returns a single source (string)
+        src = completeNamespace(source);
+        prereqs.unshift(src);
+      }
+
+      else {
+        // It's a function that returns a headache.
+        debugger;
+        throw new Error("Can't parse rule source.");
+      }
+    }
+
+    // 2: An array of sources
+    else if (source instanceof Array) {
+      // Find them all:
+      src = [];
+      source.forEach(function(srcName){
+        src.push(completeNamespace( Matcher.getSource(name, pattern, srcName) ));
+      });
+      prereqs = prereqs.concat(src);
+    } 
+
+    // 3: A single source
+    else if (typeof source == 'string') {
       src = completeNamespace( Matcher.getSource(name, pattern, source) );
-			prereqs.unshift(src);
-    }
-    else {
-			// wtf?
-			debugger;
-			throw new Error("Can't parse rule source.");
+      prereqs.unshift(src);
     }
 
-    // // TODO: Write a utility function that appends a
-    // // taskname to a namespace path
-    // src = nsPath.split(':').filter(function (item) {
-    //   return !!item;
-    // }).concat(src).join(':');
+    // 4: There is no #4
+    else {
+      throw new Error("Can't parse rule source.");
+    }
 
     // Generate the prerequisite for the matching task.
-    //    It is the original prerequisites plus the prerequisite/prerequisites
+    //    It is the original prerequisites plus the definied prerequisite/prerequisites
     //    representing source file, i.e.,
     //
     //      rule( '%.o', '%.c', ['some.h'] ...
@@ -329,14 +348,14 @@ Rule.prototype = new (function () {
       tNs = jake.currentNamespace;
       jake.currentNamespace = ns;
       createdTask = jake.createTask('file', name, prereqs, action, opts);
-			if (src instanceof Array) {
-				createdTask.source = [];
-				src.forEach(function(s){
-					createdTask.source.push(s.split(':').pop());
-				});
-			} else { 
-				createdTask.source = src.split(':').pop();
-			}
+      if (src instanceof Array) {
+        createdTask.source = [];
+        src.forEach(function(s){
+          createdTask.source.push(s.split(':').pop());
+        });
+      } else { 
+        createdTask.source = src.split(':').pop();
+      }
       jake.currentNamespace = tNs;
 
       return createdTask;

--- a/test/Jakefile.rule
+++ b/test/Jakefile.rule
@@ -1,7 +1,7 @@
 var exec = require('child_process').exec
-	, fs = require('fs')
-	, util = require('util')
-	, utils = require('utilities');
+  , fs = require('fs')
+  , util = require('util')
+  , utils = require('utilities');
 
 
 task('default', ['tmp']);
@@ -13,57 +13,57 @@ directory('tmpbin');
 ////////////////////////////////////////////////////////////
 // Simple Suffix Rule
 file('tmp', ['tmp_init', 'tmp_dep1.o', 'tmp_dep2.o'], function (params) {
-		console.log('tmp task');
-		var data1 = fs.readFileSync('tmp_dep1.o');
-		var data2 = fs.readFileSync('tmp_dep2.o');
-		fs.writeFileSync('tmp', data1 + data2);
+    console.log('tmp task');
+    var data1 = fs.readFileSync('tmp_dep1.o');
+    var data2 = fs.readFileSync('tmp_dep2.o');
+    fs.writeFileSync('tmp', data1 + data2);
 });
 
 rule('.o', '.c', function() {
-	var cmd = util.format('cp %s %s', this.source, this.name);
-	console.log(cmd + ' task');
-	jake.exec([cmd], function () {
-		complete();
-	});
+  var cmd = util.format('cp %s %s', this.source, this.name);
+  console.log(cmd + ' task');
+  jake.exec([cmd], function () {
+    complete();
+  });
 }, { async : true });
 file('tmp_dep1.c', function () {
-	fs.writeFile('tmp_dep1.c', 'src_1', function (err) {
-		if (err) {
-			throw err;
-		}
-		console.log('tmp_dep1.c task');
-		complete();
-	});
+  fs.writeFile('tmp_dep1.c', 'src_1', function (err) {
+    if (err) {
+      throw err;
+    }
+    console.log('tmp_dep1.c task');
+    complete();
+  });
 }, {async: true});
 
 // note that tmp_dep2.o depends on tmp_dep2.c, which is a
 // static file.
 task('tmp_init', function () {
-	fs.writeFile('tmp_dep2.c', 'src_2', function (err) {
-		if (err) {
-			throw err;
-		}
-		console.log('tmp_dep2.c task');
-		complete();
-	});
+  fs.writeFile('tmp_dep2.c', 'src_2', function (err) {
+    if (err) {
+      throw err;
+    }
+    console.log('tmp_dep2.c task');
+    complete();
+  });
 }, {async: true});
 ////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////
 // Pattern Rule
 file('tmp_p', ['tmp_init', 'tmp_dep1.oo', 'tmp_dep2.oo'], function (params) {
-		console.log('tmp pattern task');
-		var data1 = fs.readFileSync('tmp_dep1.oo');
-		var data2 = fs.readFileSync('tmp_dep2.oo');
-		fs.writeFileSync('tmp_p', data1 + data2 + ' pattern');
+    console.log('tmp pattern task');
+    var data1 = fs.readFileSync('tmp_dep1.oo');
+    var data2 = fs.readFileSync('tmp_dep2.oo');
+    fs.writeFileSync('tmp_p', data1 + data2 + ' pattern');
 });
 
 rule('%.oo', '%.c', function() {
-	var cmd = util.format('cp %s %s', this.source, this.name);
-	console.log(cmd + ' task');
-	jake.exec([cmd], function () {
-		complete();
-	});
+  var cmd = util.format('cp %s %s', this.source, this.name);
+  console.log(cmd + ' task');
+  jake.exec([cmd], function () {
+    complete();
+  });
 }, { async : true });
 ////////////////////////////////////////////////////////////
 
@@ -71,45 +71,45 @@ rule('%.oo', '%.c', function() {
 // Pattern Rule with Folder
 // i.e.  rule('tmpbin/%.oo', 'tmpsrc/%.c', ...
 file('tmp_pf', [
-		'tmp_src_init'
-	, 'tmpbin'
-	, 'tmpbin/tmp_dep1.oo'
-	, 'tmpbin/tmp_dep2.oo' ], function (params) {
-		console.log('tmp pattern folder task');
-		var data1 = fs.readFileSync('tmpbin/tmp_dep1.oo');
-		var data2 = fs.readFileSync('tmpbin/tmp_dep2.oo');
-		fs.writeFileSync('tmp_pf', data1 + data2 + ' pattern folder');
+    'tmp_src_init'
+  , 'tmpbin'
+  , 'tmpbin/tmp_dep1.oo'
+  , 'tmpbin/tmp_dep2.oo' ], function (params) {
+    console.log('tmp pattern folder task');
+    var data1 = fs.readFileSync('tmpbin/tmp_dep1.oo');
+    var data2 = fs.readFileSync('tmpbin/tmp_dep2.oo');
+    fs.writeFileSync('tmp_pf', data1 + data2 + ' pattern folder');
 });
 
 rule('tmpbin/%.oo', 'tmpsrc/%.c', function() {
-	var cmd = util.format('cp %s %s', this.source, this.name);
-	console.log(cmd + ' task');
-	jake.exec([cmd], function () {
-		complete();
-	});
+  var cmd = util.format('cp %s %s', this.source, this.name);
+  console.log(cmd + ' task');
+  jake.exec([cmd], function () {
+    complete();
+  });
 }, { async : true });
 
 
 
 file('tmpsrc/tmp_dep2.c',['tmpsrc'], function () {
-	fs.writeFile('tmpsrc/tmp_dep2.c', 'src/src_2', function (err) {
-		if (err) {
-			throw err;
-		}
-		console.log('tmpsrc/tmp_dep2.c task');
-		complete();
-	});
+  fs.writeFile('tmpsrc/tmp_dep2.c', 'src/src_2', function (err) {
+    if (err) {
+      throw err;
+    }
+    console.log('tmpsrc/tmp_dep2.c task');
+    complete();
+  });
 }, {async: true});
 
 // Create static files in folder tmpsrc.
 task('tmp_src_init', ['tmpsrc'], function () {
-	fs.writeFile('tmpsrc/tmp_dep1.c', 'src/src_1', function (err) {
-		if (err) {
-			throw err;
-		}
-		console.log('tmpsrc/tmp_dep1.c task');
-		complete();
-	});
+  fs.writeFile('tmpsrc/tmp_dep1.c', 'src/src_1', function (err) {
+    if (err) {
+      throw err;
+    }
+    console.log('tmpsrc/tmp_dep1.c task');
+    complete();
+  });
 }, {async: true});
 ////////////////////////////////////////////////////////////
 
@@ -119,48 +119,47 @@ task('tmp_src_init', ['tmpsrc'], function () {
 ////////////////////////////////////////////////////////////
 // Multiple Source Rule tests
 task('tmp_ms', [
-		'tmpbin',
-		'tmpbin/bar123.glom',
-		'sourceFunction:tmpbin/foo123.glom' 
-		], function () { 
-		console.log('multiple source rules task');
-		var data1 = fs.readFileSync('tmpbin/foo123.glom');
-		var data2 = fs.readFileSync('tmpbin/bar123.glom');
-		fs.writeFileSync('tmp_ms', data1 + data2 + ' multiple source rules');
+    'tmpbin',
+    'tmpbin/bar123.glom',
+    'sourceFunction:tmpbin/foo123.glom' 
+    ], function () { 
+    console.log('multiple source rules task');
+    var data1 = fs.readFileSync('tmpbin/foo123.glom');
+    var data2 = fs.readFileSync('tmpbin/bar123.glom');
+    fs.writeFileSync('tmp_ms', data1 + data2 + ' multiple source rules');
 });
 
 +function(){
-	var srcFuncMulti = function (taskName) {
-		var list = [];
-		
-		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.1') );
-		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.2') );
-		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.3') );
+  var srcFuncMulti = function (taskName) {
+    var list = [];
+    
+    list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.1') );
+    list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.2') );
+    list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.3') );
 
-		debugger;
-		return list;
-	};
+    return list;
+  };
 
-	rule(/.*\.glom$/, srcFuncMulti, function () {
-		var data = fs.readFileSync(this.source[0]);
-		data += fs.readFileSync(this.source[1]);
-		data += fs.readFileSync(this.source[2]);
-		fs.writeFileSync(this.name, data.toString());
-		console.log('created .glom');
-	});
+  rule(/.*\.glom$/, srcFuncMulti, function () {
+    var data = fs.readFileSync(this.source[0]);
+    data += fs.readFileSync(this.source[1]);
+    data += fs.readFileSync(this.source[2]);
+    fs.writeFileSync(this.name, data.toString());
+    console.log('created .glom');
+  });
 }();
 
 [1, 2, 3].forEach(function (key) {
-	var name = 'tmpsrc/bar123.' + key;
-	file(name, ['tmpsrc'], function () {
-		fs.writeFile(name, name+ "\n", function (err) {
-			if (err) {
-				throw err;
-			}
-			console.log(name + ' task');
-			complete();
-		});
-	}, {async: true});
+  var name = 'tmpsrc/bar123.' + key;
+  file(name, ['tmpsrc'], function () {
+    fs.writeFile(name, name+ "\n", function (err) {
+      if (err) {
+        throw err;
+      }
+      console.log(name + ' task');
+      complete();
+    });
+  }, {async: true});
 });
 
 ////////////////////////////////////////////////////////////
@@ -169,46 +168,46 @@ task('tmp_ms', [
 // -  rules belonging to different namespace.
 // -  rules with folder and pattern
 task('tmp_ns', [
-		'tmpbin'
-	, 'rule:init'
-	, 'tmpbin/tmp_dep2.oo'    // *** This relies on a rule defined before.
-	, 'rule:tmpbin/dep1.oo'
-	, 'rule:tmpbin/file2.oo' ], function () {
-		console.log('tmp pattern folder namespace task');
-		var data1 = fs.readFileSync('tmpbin/dep1.oo');
-		var data2 = fs.readFileSync('tmpbin/tmp_dep2.oo');
-		var data3 = fs.readFileSync('tmpbin/file2.oo');
-		fs.writeFileSync('tmp_ns', data1 + data2 + data3 + ' pattern folder namespace');
+    'tmpbin'
+  , 'rule:init'
+  , 'tmpbin/tmp_dep2.oo'    // *** This relies on a rule defined before.
+  , 'rule:tmpbin/dep1.oo'
+  , 'rule:tmpbin/file2.oo' ], function () {
+    console.log('tmp pattern folder namespace task');
+    var data1 = fs.readFileSync('tmpbin/dep1.oo');
+    var data2 = fs.readFileSync('tmpbin/tmp_dep2.oo');
+    var data3 = fs.readFileSync('tmpbin/file2.oo');
+    fs.writeFileSync('tmp_ns', data1 + data2 + data3 + ' pattern folder namespace');
 });
 
 namespace('rule', function() {
-	task('init', ['tmpsrc'], function () {
-		fs.writeFile('tmpsrc/file2.c', 'src/src_3', function (err) {
-			if (err) {
-				throw err;
-			}
-			console.log('tmpsrc/file2.c init task');
-			complete();
-		});
-	}, {async: true});
+  task('init', ['tmpsrc'], function () {
+    fs.writeFile('tmpsrc/file2.c', 'src/src_3', function (err) {
+      if (err) {
+        throw err;
+      }
+      console.log('tmpsrc/file2.c init task');
+      complete();
+    });
+  }, {async: true});
 
-	file('tmpsrc/dep1.c',['tmpsrc'], function () {
-		fs.writeFile('tmpsrc/dep1.c', 'src/src_1', function (err) {
-			if (err) {
-				throw err;
-			}
-			console.log('tmpsrc/dep1.c task');
-			complete();
-		});
-	}, {async: true});
+  file('tmpsrc/dep1.c',['tmpsrc'], function () {
+    fs.writeFile('tmpsrc/dep1.c', 'src/src_1', function (err) {
+      if (err) {
+        throw err;
+      }
+      console.log('tmpsrc/dep1.c task');
+      complete();
+    });
+  }, {async: true});
 
-	rule('tmpbin/%.oo', 'tmpsrc/%.c', function() {
-		var cmd = util.format('cp %s %s', this.source, this.name);
-		console.log(cmd + ' ns task');
-		jake.exec([cmd], function () {
-			complete();
-		});
-	}, { async : true });
+  rule('tmpbin/%.oo', 'tmpsrc/%.c', function() {
+    var cmd = util.format('cp %s %s', this.source, this.name);
+    console.log(cmd + ' ns task');
+    jake.exec([cmd], function () {
+      complete();
+    });
+  }, { async : true });
 });
 ////////////////////////////////////////////////////////////
 
@@ -217,117 +216,116 @@ namespace('rule', function() {
 // rule('tmpbin/%.pdf', 'tmpbin/%.dvi', function() { ...
 // rule('tmpbin/%.dvi', 'tmpsrc/%.tex', ['tmpbin'], function() { ...
 task('tmp_cr', [
-		'chainrule:init'
-	, 'chainrule:tmpbin/file1.pdf'
-	, 'chainrule:tmpbin/file2.pdf' ], function () {
-		console.log('tmp chainrule namespace task');
-		var data1 = fs.readFileSync('tmpbin/file1.pdf');
-		var data2 = fs.readFileSync('tmpbin/file2.pdf');
-		fs.writeFileSync('tmp_cr', data1 + data2 + ' chainrule namespace');
+    'chainrule:init'
+  , 'chainrule:tmpbin/file1.pdf'
+  , 'chainrule:tmpbin/file2.pdf' ], function () {
+    console.log('tmp chainrule namespace task');
+    var data1 = fs.readFileSync('tmpbin/file1.pdf');
+    var data2 = fs.readFileSync('tmpbin/file2.pdf');
+    fs.writeFileSync('tmp_cr', data1 + data2 + ' chainrule namespace');
 });
 
 namespace('chainrule', function() {
-	task('init', ['tmpsrc', 'tmpbin'], function () {
-		fs.writeFileSync('tmpsrc/file1.tex', 'tex1 ');
-		fs.writeFileSync('tmpsrc/file2.tex', 'tex2 ');
-		console.log('chainrule init task');
-	});
+  task('init', ['tmpsrc', 'tmpbin'], function () {
+    fs.writeFileSync('tmpsrc/file1.tex', 'tex1 ');
+    fs.writeFileSync('tmpsrc/file2.tex', 'tex2 ');
+    console.log('chainrule init task');
+  });
 
-	rule('tmpbin/%.pdf', 'tmpbin/%.dvi', function() {
-		var cmd = util.format('cp %s %s', this.source, this.name);
-		console.log(cmd + ' dvi->pdf task');
-		jake.exec([cmd], function () {
-			complete();
-		});
-	}, { async : true });
+  rule('tmpbin/%.pdf', 'tmpbin/%.dvi', function() {
+    var cmd = util.format('cp %s %s', this.source, this.name);
+    console.log(cmd + ' dvi->pdf task');
+    jake.exec([cmd], function () {
+      complete();
+    });
+  }, { async : true });
 
-	rule('tmpbin/%.dvi', 'tmpsrc/%.tex', ['tmpbin'], function() {
-		var cmd = util.format('cp %s %s', this.source, this.name);
-		console.log(cmd + ' tex->dvi task');
-		jake.exec([cmd], function () {
-			complete();
-		});
-	}, { async : true });
+  rule('tmpbin/%.dvi', 'tmpsrc/%.tex', ['tmpbin'], function() {
+    var cmd = util.format('cp %s %s', this.source, this.name);
+    console.log(cmd + ' tex->dvi task');
+    jake.exec([cmd], function () {
+      complete();
+    });
+  }, { async : true });
 });
 ////////////////////////////////////////////////////////////
 namespace('precedence', function () {
-	task('test', ['foo.html'], function () {
-		console.log('ran test');
-	});
+  task('test', ['foo.html'], function () {
+    console.log('ran test');
+  });
 
-	rule('.html', '.txt', function () {
-		console.log('created html');
-		var data = fs.readFileSync(this.source);
-		fs.writeFileSync(this.name, data.toString());
-	});
+  rule('.html', '.txt', function () {
+    console.log('created html');
+    var data = fs.readFileSync(this.source);
+    fs.writeFileSync(this.name, data.toString());
+  });
 });
 
 namespace('regexPattern', function () {
-	task('test', ['foo.html'], function () {
-		console.log('ran test');
-	});
+  task('test', ['foo.html'], function () {
+    console.log('ran test');
+  });
 
-	rule(/\.html$/, '.txt', function () {
-debugger;
-		console.log('created html');
-		var data = fs.readFileSync(this.source);
-		fs.writeFileSync(this.name, data.toString());
-	});
+  rule(/\.html$/, '.txt', function () {
+    console.log('created html');
+    var data = fs.readFileSync(this.source);
+    fs.writeFileSync(this.name, data.toString());
+  });
 });
 
 namespace('sourceFunction', function () {
 
-	var srcFunc = function (taskName) {
-		/* console.log(taskName.replace(/\.[^.]+$/, '.txt')); */
-		return taskName.replace(/\.[^.]+$/, '.txt');
-	};
+  var srcFunc = function (taskName) {
+    /* console.log(taskName.replace(/\.[^.]+$/, '.txt')); */
+    return taskName.replace(/\.[^.]+$/, '.txt');
+  };
 
-	task('test', ['foo.html'], function () {
-		console.log('ran test');
-	});
+  task('test', ['foo.html'], function () {
+    console.log('ran test');
+  });
 
-	rule('.html', srcFunc, function () {
-		console.log('created html');
-		var data = fs.readFileSync(this.source);
-		fs.writeFileSync(this.name, data.toString());
-	});
+  rule('.html', srcFunc, function () {
+    console.log('created html');
+    var data = fs.readFileSync(this.source);
+    fs.writeFileSync(this.name, data.toString());
+  });
 
-	var srcFuncMulti = function (taskName) {
-		var list = [];
+  var srcFuncMulti = function (taskName) {
+    var list = [];
 
-		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.1') );
-		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.2') );
-		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.3') );
+    list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.1') );
+    list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.2') );
+    list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.3') );
 
-		return list;
-	};
+    return list;
+  };
 
-	// Testing multiple rule sources returned by a function:
+  // Testing multiple rule sources returned by a function:
 
-	rule(/.*\.glom$/, srcFuncMulti, function () {
-		var data = fs.readFileSync(this.source[0]);
-		data += fs.readFileSync(this.source[1]);
-		data += fs.readFileSync(this.source[2]);
-		fs.writeFileSync(this.name, data.toString());
-		console.log('created .glom');
-	});
+  rule(/.*\.glom$/, srcFuncMulti, function () {
+    var data = fs.readFileSync(this.source[0]);
+    data += fs.readFileSync(this.source[1]);
+    data += fs.readFileSync(this.source[2]);
+    fs.writeFileSync(this.name, data.toString());
+    console.log('created .glom');
+  });
 
-	[1, 2, 3].forEach(function (key) {
-		var name = 'tmpsrc/foo123.' + key;
-		file(name, ['tmpsrc'], function () {
-			fs.writeFile(name, name+ "\n", function (err) {
-				if (err) {
-					throw err;
-				}
-				console.log(name + ' task');
-			complete();
-		});
-	}, {async: true});
+  [1, 2, 3].forEach(function (key) {
+    var name = 'tmpsrc/foo123.' + key;
+    file(name, ['tmpsrc'], function () {
+      fs.writeFile(name, name+ "\n", function (err) {
+        if (err) {
+          throw err;
+        }
+        console.log(name + ' task');
+      complete();
+    });
+  }, {async: true});
 });
 
 });
 ////////////////////////////////////////////////////////////
 task('clean', function () {
-utils.file.rmRf('./foo');
-utils.file.rmRf('./tmp');
+  utils.file.rmRf('./foo');
+  utils.file.rmRf('./tmp');
 });

--- a/test/Jakefile.rule
+++ b/test/Jakefile.rule
@@ -1,7 +1,7 @@
 var exec = require('child_process').exec
-  , fs = require('fs')
-  , util = require('util')
-  , utils = require('utilities');
+	, fs = require('fs')
+	, util = require('util')
+	, utils = require('utilities');
 
 
 task('default', ['tmp']);
@@ -9,60 +9,61 @@ task('default', ['tmp']);
 directory('tmpsrc');
 directory('tmpbin');
 
+
 ////////////////////////////////////////////////////////////
 // Simple Suffix Rule
 file('tmp', ['tmp_init', 'tmp_dep1.o', 'tmp_dep2.o'], function (params) {
-    console.log('tmp task');
-    var data1 = fs.readFileSync('tmp_dep1.o');
-    var data2 = fs.readFileSync('tmp_dep2.o');
-    fs.writeFileSync('tmp', data1 + data2);
+		console.log('tmp task');
+		var data1 = fs.readFileSync('tmp_dep1.o');
+		var data2 = fs.readFileSync('tmp_dep2.o');
+		fs.writeFileSync('tmp', data1 + data2);
 });
 
 rule('.o', '.c', function() {
-  var cmd = util.format('cp %s %s', this.source, this.name);
-  console.log(cmd + ' task');
-  jake.exec([cmd], function () {
-    complete();
-  });
+	var cmd = util.format('cp %s %s', this.source, this.name);
+	console.log(cmd + ' task');
+	jake.exec([cmd], function () {
+		complete();
+	});
 }, { async : true });
 file('tmp_dep1.c', function () {
-  fs.writeFile('tmp_dep1.c', 'src_1', function (err) {
-    if (err) {
-      throw err;
-    }
-    console.log('tmp_dep1.c task');
-    complete();
-  });
+	fs.writeFile('tmp_dep1.c', 'src_1', function (err) {
+		if (err) {
+			throw err;
+		}
+		console.log('tmp_dep1.c task');
+		complete();
+	});
 }, {async: true});
 
 // note that tmp_dep2.o depends on tmp_dep2.c, which is a
 // static file.
 task('tmp_init', function () {
-  fs.writeFile('tmp_dep2.c', 'src_2', function (err) {
-    if (err) {
-      throw err;
-    }
-    console.log('tmp_dep2.c task');
-    complete();
-  });
+	fs.writeFile('tmp_dep2.c', 'src_2', function (err) {
+		if (err) {
+			throw err;
+		}
+		console.log('tmp_dep2.c task');
+		complete();
+	});
 }, {async: true});
 ////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////
 // Pattern Rule
 file('tmp_p', ['tmp_init', 'tmp_dep1.oo', 'tmp_dep2.oo'], function (params) {
-    console.log('tmp pattern task');
-    var data1 = fs.readFileSync('tmp_dep1.oo');
-    var data2 = fs.readFileSync('tmp_dep2.oo');
-    fs.writeFileSync('tmp_p', data1 + data2 + ' pattern');
+		console.log('tmp pattern task');
+		var data1 = fs.readFileSync('tmp_dep1.oo');
+		var data2 = fs.readFileSync('tmp_dep2.oo');
+		fs.writeFileSync('tmp_p', data1 + data2 + ' pattern');
 });
 
 rule('%.oo', '%.c', function() {
-  var cmd = util.format('cp %s %s', this.source, this.name);
-  console.log(cmd + ' task');
-  jake.exec([cmd], function () {
-    complete();
-  });
+	var cmd = util.format('cp %s %s', this.source, this.name);
+	console.log(cmd + ' task');
+	jake.exec([cmd], function () {
+		complete();
+	});
 }, { async : true });
 ////////////////////////////////////////////////////////////
 
@@ -70,48 +71,97 @@ rule('%.oo', '%.c', function() {
 // Pattern Rule with Folder
 // i.e.  rule('tmpbin/%.oo', 'tmpsrc/%.c', ...
 file('tmp_pf', [
-    'tmp_src_init'
-  , 'tmpbin'
-  , 'tmpbin/tmp_dep1.oo'
-  , 'tmpbin/tmp_dep2.oo' ], function (params) {
-    console.log('tmp pattern folder task');
-    var data1 = fs.readFileSync('tmpbin/tmp_dep1.oo');
-    var data2 = fs.readFileSync('tmpbin/tmp_dep2.oo');
-    fs.writeFileSync('tmp_pf', data1 + data2 + ' pattern folder');
+		'tmp_src_init'
+	, 'tmpbin'
+	, 'tmpbin/tmp_dep1.oo'
+	, 'tmpbin/tmp_dep2.oo' ], function (params) {
+		console.log('tmp pattern folder task');
+		var data1 = fs.readFileSync('tmpbin/tmp_dep1.oo');
+		var data2 = fs.readFileSync('tmpbin/tmp_dep2.oo');
+		fs.writeFileSync('tmp_pf', data1 + data2 + ' pattern folder');
 });
 
 rule('tmpbin/%.oo', 'tmpsrc/%.c', function() {
-  var cmd = util.format('cp %s %s', this.source, this.name);
-  console.log(cmd + ' task');
-  jake.exec([cmd], function () {
-    complete();
-  });
+	var cmd = util.format('cp %s %s', this.source, this.name);
+	console.log(cmd + ' task');
+	jake.exec([cmd], function () {
+		complete();
+	});
 }, { async : true });
 
 
 
 file('tmpsrc/tmp_dep2.c',['tmpsrc'], function () {
-  fs.writeFile('tmpsrc/tmp_dep2.c', 'src/src_2', function (err) {
-    if (err) {
-      throw err;
-    }
-    console.log('tmpsrc/tmp_dep2.c task');
-    complete();
-  });
+	fs.writeFile('tmpsrc/tmp_dep2.c', 'src/src_2', function (err) {
+		if (err) {
+			throw err;
+		}
+		console.log('tmpsrc/tmp_dep2.c task');
+		complete();
+	});
 }, {async: true});
 
 // Create static files in folder tmpsrc.
 task('tmp_src_init', ['tmpsrc'], function () {
-  fs.writeFile('tmpsrc/tmp_dep1.c', 'src/src_1', function (err) {
-    if (err) {
-      throw err;
-    }
-    console.log('tmpsrc/tmp_dep1.c task');
-    complete();
-  });
+	fs.writeFile('tmpsrc/tmp_dep1.c', 'src/src_1', function (err) {
+		if (err) {
+			throw err;
+		}
+		console.log('tmpsrc/tmp_dep1.c task');
+		complete();
+	});
 }, {async: true});
 ////////////////////////////////////////////////////////////
 
+//////////////////////////////////////////////////////
+// Rule having multiple sources
+
+////////////////////////////////////////////////////////////
+// Multiple Source Rule tests
+task('tmp_ms', [
+		'tmpbin',
+		'tmpbin/bar123.glom',
+		'sourceFunction:tmpbin/foo123.glom' 
+		], function () { 
+		console.log('multiple source rules task');
+		var data1 = fs.readFileSync('tmpbin/foo123.glom');
+		var data2 = fs.readFileSync('tmpbin/bar123.glom');
+		fs.writeFileSync('tmp_ms', data1 + data2 + ' multiple source rules');
+});
+
++function(){
+	var srcFuncMulti = function (taskName) {
+		var list = [];
+		
+		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.1') );
+		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.2') );
+		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.3') );
+
+		debugger;
+		return list;
+	};
+
+	rule(/.*\.glom$/, srcFuncMulti, function () {
+		var data = fs.readFileSync(this.source[0]);
+		data += fs.readFileSync(this.source[1]);
+		data += fs.readFileSync(this.source[2]);
+		fs.writeFileSync(this.name, data.toString());
+		console.log('created .glom');
+	});
+}();
+
+[1, 2, 3].forEach(function (key) {
+	var name = 'tmpsrc/bar123.' + key;
+	file(name, ['tmpsrc'], function () {
+		fs.writeFile(name, name+ "\n", function (err) {
+			if (err) {
+				throw err;
+			}
+			console.log(name + ' task');
+			complete();
+		});
+	}, {async: true});
+});
 
 ////////////////////////////////////////////////////////////
 // Namespace Test. This is a Mixed Test.
@@ -119,46 +169,46 @@ task('tmp_src_init', ['tmpsrc'], function () {
 // -  rules belonging to different namespace.
 // -  rules with folder and pattern
 task('tmp_ns', [
-    'tmpbin'
-  , 'rule:init'
-  , 'tmpbin/tmp_dep2.oo'    // *** This relies on a rule defined before.
-  , 'rule:tmpbin/dep1.oo'
-  , 'rule:tmpbin/file2.oo' ], function () {
-    console.log('tmp pattern folder namespace task');
-    var data1 = fs.readFileSync('tmpbin/dep1.oo');
-    var data2 = fs.readFileSync('tmpbin/tmp_dep2.oo');
-    var data3 = fs.readFileSync('tmpbin/file2.oo');
-    fs.writeFileSync('tmp_ns', data1 + data2 + data3 + ' pattern folder namespace');
+		'tmpbin'
+	, 'rule:init'
+	, 'tmpbin/tmp_dep2.oo'    // *** This relies on a rule defined before.
+	, 'rule:tmpbin/dep1.oo'
+	, 'rule:tmpbin/file2.oo' ], function () {
+		console.log('tmp pattern folder namespace task');
+		var data1 = fs.readFileSync('tmpbin/dep1.oo');
+		var data2 = fs.readFileSync('tmpbin/tmp_dep2.oo');
+		var data3 = fs.readFileSync('tmpbin/file2.oo');
+		fs.writeFileSync('tmp_ns', data1 + data2 + data3 + ' pattern folder namespace');
 });
 
 namespace('rule', function() {
-  task('init', ['tmpsrc'], function () {
-    fs.writeFile('tmpsrc/file2.c', 'src/src_3', function (err) {
-      if (err) {
-        throw err;
-      }
-      console.log('tmpsrc/file2.c init task');
-      complete();
-    });
-  }, {async: true});
+	task('init', ['tmpsrc'], function () {
+		fs.writeFile('tmpsrc/file2.c', 'src/src_3', function (err) {
+			if (err) {
+				throw err;
+			}
+			console.log('tmpsrc/file2.c init task');
+			complete();
+		});
+	}, {async: true});
 
-  file('tmpsrc/dep1.c',['tmpsrc'], function () {
-    fs.writeFile('tmpsrc/dep1.c', 'src/src_1', function (err) {
-      if (err) {
-        throw err;
-      }
-      console.log('tmpsrc/dep1.c task');
-      complete();
-    });
-  }, {async: true});
+	file('tmpsrc/dep1.c',['tmpsrc'], function () {
+		fs.writeFile('tmpsrc/dep1.c', 'src/src_1', function (err) {
+			if (err) {
+				throw err;
+			}
+			console.log('tmpsrc/dep1.c task');
+			complete();
+		});
+	}, {async: true});
 
-  rule('tmpbin/%.oo', 'tmpsrc/%.c', function() {
-    var cmd = util.format('cp %s %s', this.source, this.name);
-    console.log(cmd + ' ns task');
-    jake.exec([cmd], function () {
-      complete();
-    });
-  }, { async : true });
+	rule('tmpbin/%.oo', 'tmpsrc/%.c', function() {
+		var cmd = util.format('cp %s %s', this.source, this.name);
+		console.log(cmd + ' ns task');
+		jake.exec([cmd], function () {
+			complete();
+		});
+	}, { async : true });
 });
 ////////////////////////////////////////////////////////////
 
@@ -167,82 +217,117 @@ namespace('rule', function() {
 // rule('tmpbin/%.pdf', 'tmpbin/%.dvi', function() { ...
 // rule('tmpbin/%.dvi', 'tmpsrc/%.tex', ['tmpbin'], function() { ...
 task('tmp_cr', [
-    'chainrule:init'
-  , 'chainrule:tmpbin/file1.pdf'
-  , 'chainrule:tmpbin/file2.pdf' ], function () {
-    console.log('tmp chainrule namespace task');
-    var data1 = fs.readFileSync('tmpbin/file1.pdf');
-    var data2 = fs.readFileSync('tmpbin/file2.pdf');
-    fs.writeFileSync('tmp_cr', data1 + data2 + ' chainrule namespace');
+		'chainrule:init'
+	, 'chainrule:tmpbin/file1.pdf'
+	, 'chainrule:tmpbin/file2.pdf' ], function () {
+		console.log('tmp chainrule namespace task');
+		var data1 = fs.readFileSync('tmpbin/file1.pdf');
+		var data2 = fs.readFileSync('tmpbin/file2.pdf');
+		fs.writeFileSync('tmp_cr', data1 + data2 + ' chainrule namespace');
 });
 
 namespace('chainrule', function() {
-  task('init', ['tmpsrc', 'tmpbin'], function () {
-    fs.writeFileSync('tmpsrc/file1.tex', 'tex1 ');
-    fs.writeFileSync('tmpsrc/file2.tex', 'tex2 ');
-    console.log('chainrule init task');
-  });
+	task('init', ['tmpsrc', 'tmpbin'], function () {
+		fs.writeFileSync('tmpsrc/file1.tex', 'tex1 ');
+		fs.writeFileSync('tmpsrc/file2.tex', 'tex2 ');
+		console.log('chainrule init task');
+	});
 
-  rule('tmpbin/%.pdf', 'tmpbin/%.dvi', function() {
-    var cmd = util.format('cp %s %s', this.source, this.name);
-    console.log(cmd + ' dvi->pdf task');
-    jake.exec([cmd], function () {
-      complete();
-    });
-  }, { async : true });
+	rule('tmpbin/%.pdf', 'tmpbin/%.dvi', function() {
+		var cmd = util.format('cp %s %s', this.source, this.name);
+		console.log(cmd + ' dvi->pdf task');
+		jake.exec([cmd], function () {
+			complete();
+		});
+	}, { async : true });
 
-  rule('tmpbin/%.dvi', 'tmpsrc/%.tex', ['tmpbin'], function() {
-    var cmd = util.format('cp %s %s', this.source, this.name);
-    console.log(cmd + ' tex->dvi task');
-    jake.exec([cmd], function () {
-      complete();
-    });
-  }, { async : true });
+	rule('tmpbin/%.dvi', 'tmpsrc/%.tex', ['tmpbin'], function() {
+		var cmd = util.format('cp %s %s', this.source, this.name);
+		console.log(cmd + ' tex->dvi task');
+		jake.exec([cmd], function () {
+			complete();
+		});
+	}, { async : true });
 });
 ////////////////////////////////////////////////////////////
 namespace('precedence', function () {
-  task('test', ['foo.html'], function () {
-    console.log('ran test');
-  });
+	task('test', ['foo.html'], function () {
+		console.log('ran test');
+	});
 
-  rule('.html', '.txt', function () {
-    console.log('created html');
-    var data = fs.readFileSync(this.source);
-    fs.writeFileSync(this.name, data.toString());
-  });
+	rule('.html', '.txt', function () {
+		console.log('created html');
+		var data = fs.readFileSync(this.source);
+		fs.writeFileSync(this.name, data.toString());
+	});
 });
 
 namespace('regexPattern', function () {
-  task('test', ['foo.html'], function () {
-    console.log('ran test');
-  });
+	task('test', ['foo.html'], function () {
+		console.log('ran test');
+	});
 
-  rule(/\.html$/, '.txt', function () {
-    console.log('created html');
-    var data = fs.readFileSync(this.source);
-    fs.writeFileSync(this.name, data.toString());
-  });
+	rule(/\.html$/, '.txt', function () {
+debugger;
+		console.log('created html');
+		var data = fs.readFileSync(this.source);
+		fs.writeFileSync(this.name, data.toString());
+	});
 });
 
 namespace('sourceFunction', function () {
 
-  var srcFunc = function (taskName) {
-    return taskName.replace(/\.[^.]+$/, '.txt');
-  };
+	var srcFunc = function (taskName) {
+		/* console.log(taskName.replace(/\.[^.]+$/, '.txt')); */
+		return taskName.replace(/\.[^.]+$/, '.txt');
+	};
 
-  task('test', ['foo.html'], function () {
-    console.log('ran test');
-  });
+	task('test', ['foo.html'], function () {
+		console.log('ran test');
+	});
 
-  rule('.html', srcFunc, function () {
-    console.log('created html');
-    var data = fs.readFileSync(this.source);
-    fs.writeFileSync(this.name, data.toString());
-  });
+	rule('.html', srcFunc, function () {
+		console.log('created html');
+		var data = fs.readFileSync(this.source);
+		fs.writeFileSync(this.name, data.toString());
+	});
+
+	var srcFuncMulti = function (taskName) {
+		var list = [];
+
+		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.1') );
+		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.2') );
+		list.push(taskName.replace('tmpbin', 'tmpsrc').replace(/\.[^.]+$/, '.3') );
+
+		return list;
+	};
+
+	// Testing multiple rule sources returned by a function:
+
+	rule(/.*\.glom$/, srcFuncMulti, function () {
+		var data = fs.readFileSync(this.source[0]);
+		data += fs.readFileSync(this.source[1]);
+		data += fs.readFileSync(this.source[2]);
+		fs.writeFileSync(this.name, data.toString());
+		console.log('created .glom');
+	});
+
+	[1, 2, 3].forEach(function (key) {
+		var name = 'tmpsrc/foo123.' + key;
+		file(name, ['tmpsrc'], function () {
+			fs.writeFile(name, name+ "\n", function (err) {
+				if (err) {
+					throw err;
+				}
+				console.log(name + ' task');
+			complete();
+		});
+	}, {async: true});
 });
 
+});
 ////////////////////////////////////////////////////////////
 task('clean', function () {
-  utils.file.rmRf('./foo');
-  utils.file.rmRf('./tmp');
+utils.file.rmRf('./foo');
+utils.file.rmRf('./tmp');
 });

--- a/test/rule.js
+++ b/test/rule.js
@@ -144,109 +144,109 @@ var tests = {
 
 , 'test rule w multiple source': function (next) {
     h.exec( '../bin/cli.js  -f Jakefile.rule tmp_ms', function (out) {
-			debugger;
+      debugger;
       var output = [
-				"tmpsrc/bar123.1 task"
-			, "tmpsrc/bar123.2 task"
-			, "tmpsrc/bar123.3 task"
-			, "created .glom"
-			, "tmpsrc/foo123.1 task"
-			, "tmpsrc/foo123.2 task"
-			, "tmpsrc/foo123.3 task"
-			, "created .glom"
-			, "multiple source rules task" ];
-			var data;
-			assert.equal( output.join('\n') , out);
-			data = fs.readFileSync(process.cwd() + '/tmp_ms');
-			assert.equal([
-				'tmpsrc/foo123.1', 
-				'tmpsrc/foo123.2', 
-				'tmpsrc/foo123.3', 
-				'tmpsrc/bar123.1', 
-				'tmpsrc/bar123.2', 
-				'tmpsrc/bar123.3', 
-				' multiple source rules'].join("\n"), data.toString());
-			cleanUpAndNext(next);
-		});
-	}
+        "tmpsrc/bar123.1 task"
+      , "tmpsrc/bar123.2 task"
+      , "tmpsrc/bar123.3 task"
+      , "created .glom"
+      , "tmpsrc/foo123.1 task"
+      , "tmpsrc/foo123.2 task"
+      , "tmpsrc/foo123.3 task"
+      , "created .glom"
+      , "multiple source rules task" ];
+      var data;
+      assert.equal( output.join('\n') , out);
+      data = fs.readFileSync(process.cwd() + '/tmp_ms');
+      assert.equal([
+        'tmpsrc/foo123.1', 
+        'tmpsrc/foo123.2', 
+        'tmpsrc/foo123.3', 
+        'tmpsrc/bar123.1', 
+        'tmpsrc/bar123.2', 
+        'tmpsrc/bar123.3', 
+        ' multiple source rules'].join("\n"), data.toString());
+      cleanUpAndNext(next);
+    });
+  }
 
 };
 
 ['precedence', 'regexPattern', 'sourceFunction'].forEach(function (key) {
 
-	tests['test rule with source file not created yet (' + key  + ')'] = function (next) {
-		utils.file.rmRf('foo.txt', {silent: true});
-		utils.file.rmRf('foo.html', {silent: true});
-		h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', {breakOnError: false},
-				function (out) {
-			// foo.txt prereq doesn't exist yet
-			assert.ok(out.toString().indexOf('Unknown task "foo.html"') > -1);
-			next();
-		});
-	};
+  tests['test rule with source file not created yet (' + key  + ')'] = function (next) {
+    utils.file.rmRf('foo.txt', {silent: true});
+    utils.file.rmRf('foo.html', {silent: true});
+    h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', {breakOnError: false},
+        function (out) {
+      // foo.txt prereq doesn't exist yet
+      assert.ok(out.toString().indexOf('Unknown task "foo.html"') > -1);
+      next();
+    });
+  };
 
-	tests['test rule with source file now created (' + key  + ')'] = function (next) {
-		fs.writeFileSync('foo.txt', '');
-		h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', function (out) {
-			// Should run prereq and test task
-			var output = [
-				'created html'
-			, 'ran test'
-			];
-			assert.equal(output.join('\n'), out);
-			next();
-		});
-	};
+  tests['test rule with source file now created (' + key  + ')'] = function (next) {
+    fs.writeFileSync('foo.txt', '');
+    h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', function (out) {
+      // Should run prereq and test task
+      var output = [
+        'created html'
+      , 'ran test'
+      ];
+      assert.equal(output.join('\n'), out);
+      next();
+    });
+  };
 
-	/*
-	tests['test rule with objective file now created (' + key  + ')'] = function (next) {
-		fs.writeFileSync('foo.txt', '');
-		h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', function (out) {
-			// Should only run test task
-			var output = [
-				'ran test'
-			];
-			assert.equal(output.join('\n'), out);
-			next();
-		});
-	};
-	*/
+  /*
+  tests['test rule with objective file now created (' + key  + ')'] = function (next) {
+    fs.writeFileSync('foo.txt', '');
+    h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', function (out) {
+      // Should only run test task
+      var output = [
+        'ran test'
+      ];
+      assert.equal(output.join('\n'), out);
+      next();
+    });
+  };
+  */
 
-	tests['test rule with source file modified (' + key  + ')'] = function (next) {
-		setTimeout(function () {
-			fs.writeFile('foo.txt', '', function (err, data) {
-				if (err) {
-					throw err;
-				}
-				h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', function (out) {
-					// Should again run both prereq and test task
-					var output = [
-						'created html'
-					, 'ran test'
-					];
-					assert.equal(output.join('\n'), out);
-					//next();
-					cleanUpAndNext(next);
-				});
-			});
-		}, 1000); // Wait to do the touch to ensure mod-time is different
-	};
+  tests['test rule with source file modified (' + key  + ')'] = function (next) {
+    setTimeout(function () {
+      fs.writeFile('foo.txt', '', function (err, data) {
+        if (err) {
+          throw err;
+        }
+        h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', function (out) {
+          // Should again run both prereq and test task
+          var output = [
+            'created html'
+          , 'ran test'
+          ];
+          assert.equal(output.join('\n'), out);
+          //next();
+          cleanUpAndNext(next);
+        });
+      });
+    }, 1000); // Wait to do the touch to ensure mod-time is different
+  };
 
-	tests['test rule with existing objective file and no source ' +
-			' (should be normal file-task) (' + key  + ')'] = function (next) {
-		// Remove just the source file
-		fs.writeFileSync('foo.html', '');
-		utils.file.rmRf('foo.txt', {silent: true});
-		h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', function (out) {
-			// Should treat existing objective file as plain file-task,
-			// and just run test-task
-			var output = [
-				'ran test'
-			];
-			assert.equal(output.join('\n'), out);
-			cleanUpAndNext(next);
-		});
-	};
+  tests['test rule with existing objective file and no source ' +
+      ' (should be normal file-task) (' + key  + ')'] = function (next) {
+    // Remove just the source file
+    fs.writeFileSync('foo.html', '');
+    utils.file.rmRf('foo.txt', {silent: true});
+    h.exec('../bin/cli.js  -f Jakefile.rule ' + key + ':test', function (out) {
+      // Should treat existing objective file as plain file-task,
+      // and just run test-task
+      var output = [
+        'ran test'
+      ];
+      assert.equal(output.join('\n'), out);
+      cleanUpAndNext(next);
+    });
+  };
 
 });
 


### PR DESCRIPTION
With this change, the second argument to rule() can be an array of source file names.  That makes rules more powerful, and more orthogonal to how fileTasks already specify their requirements.

This change also extends the functionality when the second argument is a function; that function may return such an array of sources, instead of just a single source.  (This is particularly handy for my work, and also seems orthogonal to how rules & fileTasks work generally.)