### PR TITLE
Make bash_completion script location agnostic

### DIFF
--- a/bin/bash_completion.sh
+++ b/bin/bash_completion.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-# http://stackoverflow.com/a/246128
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-  SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-done
-JAKE_BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-
 # http://stackoverflow.com/a/12495480
 # http://stackoverflow.com/a/28647824
 _auto_jake()
@@ -17,8 +8,16 @@ _auto_jake()
     local -a COMPGEN=()
     _get_comp_words_by_ref -n : -c cur
     
+    local jake_bin="$(which jake)"
+
+    if [ "$jake_bin" = "" ]; then
+      return 0
+    fi
+
+    local jake_bin_dir="$(cd $(dirname "$jake_bin") && cd $(dirname $(readlink jake)) && pwd)"
+    
     # run auto-completions in jake via our auto_complete.js wrapper
-    local -a auto_complete_info=( $(export COMP_LINE="${COMP_LINE}" && ${JAKE_BIN_DIR}/auto_complete.js "$cur" "${3}") )
+    local -a auto_complete_info=( $(export COMP_LINE="${COMP_LINE}" && ${jake_bin_dir}/auto_complete.js "$cur" "${3}") )
     # check reply flag
     local reply_flag="${auto_complete_info[0]}"
     if [[ "${reply_flag}" == "no-complete" ]]; then


### PR DESCRIPTION
Resolves auto_complete.js location using the `jake` executable location. This way it does not matter where the bash_completion.sh is located. Useful for people who want ship autocomplete files with their own dotfiles repository.


As an example here's mine https://github.com/epeli/vimconfig/tree/3cb91e647a8554e76d0253408c49f39f59830e3d/others