### PR TITLE
Jake exceeds stack when a task has many prereqs

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -141,12 +141,16 @@ TaskBase = new (function () {
 
           //Test for circular invocation
           if(prereq === currenttask) {
-            cb(new Error("Cannot use prereq " + prereq.name + " as a dependency of itself"));
+            async.setImmediate(function() {
+              cb(new Error("Cannot use prereq " + prereq.name + " as a dependency of itself"));
+            });
           }
 
           if (prereq.taskStatus === Task.runStatuses.DONE) {
             //prereq already done, return
-            cb();
+            async.setImmediate(function() {
+              cb();
+            });
           } else {
             //wait for complete before calling cb
             prereq.once('complete', function () {

--- a/test/Jakefile
+++ b/test/Jakefile
@@ -364,3 +364,20 @@ namespace('test', function() {
     this.testFiles.include('namespaced_test_task');
   });
 });
+
+namespace("large", function() {
+  desc("Leaf task");
+  task("leaf", [], function() {
+    console.log("large:leaf");
+  });
+
+  var leaves = [];
+  for (var i = 0; i < 5000; i++) {
+    leaves.push("large:leaf");
+  }
+
+  desc("Task with a large number of prereqs");
+  task("root", leaves, {parallelLimit: 2}, function() {
+    console.log("large:root");
+  });
+});

--- a/test/task_base.js
+++ b/test/task_base.js
@@ -196,6 +196,13 @@ var tests = {
     });
   }
 
+, 'test large number of prereqs': function (next) {
+    h.exec('../bin/cli.js large:root', function (out) {
+      assert.equal(out, 'large:leaf\nlarge:root');
+      next();
+    });
+  }
+
 };
 
 function _getAutoCompleteOpts(args) {


### PR DESCRIPTION
When a task has many prereqs, Jake exceeds the node process stack,
because it calls async callbacks from within a callback, recursively.

Traceback looks something like this:
RangeError: Maximum call stack size exceeded
    at parsePrereqName (jake/lib/task/task.js:44:34)
    at jake/lib/task/task.js:132:24
    at replenish (jake/node_modules/async/lib/async.js:191:21)
    at jake/node_modules/async/lib/async.js:203:33
    at jake/lib/task/task.js:149:13
    at replenish (jake/node_modules/async/lib/async.js:191:21)
    at jake/node_modules/async/lib/async.js:203:33
    at jake/lib/task/task.js:149:13
    at replenish (jake/node_modules/async/lib/async.js:191:21)
    at jake/node_modules/async/lib/async.js:203:33

This fixes the problem by deferring the callback with
async.setImmediate, as described in the section
"Synchronous iteration functions" on this page:
https://caolan.github.io/async/index.html

This also adds a testcase that fails without this fix.