### PR TITLE
fix "jake -ls" padding

### DIFF
--- a/lib/jake.js
+++ b/lib/jake.js
@@ -131,11 +131,16 @@ utils.mixin(jake, new (function () {
       , filter = typeof f == 'string' ? f : null;
 
     for (p in jake.Task) {
+      if (filter && p.indexOf(filter) == -1) {
+        continue;
+      }
       task = jake.Task[p];
       // Record the length of the longest task name -- used for
       // pretty alignment of the task descriptions
-      maxTaskNameLength = p.length > maxTaskNameLength ?
-        p.length : maxTaskNameLength;
+      if (task.description) {
+        maxTaskNameLength = p.length > maxTaskNameLength ?
+          p.length : maxTaskNameLength;
+      }
     }
     // Print out each entry with descriptions neatly aligned
     for (p in jake.Task) {
@@ -147,12 +152,13 @@ utils.mixin(jake, new (function () {
       //name = '\033[32m' + p + '\033[39m ';
       name = chalk.green(p);
 
-      // Create padding-string with calculated length
-      padding = (new Array(maxTaskNameLength - p.length + 2)).join(' ');
-
       descr = task.description;
       if (descr) {
         descr = chalk.gray(descr);
+
+        // Create padding-string with calculated length
+        padding = (new Array(maxTaskNameLength - p.length + 2)).join(' ');
+
         console.log('jake ' + name + padding + descr);
       }
     }


### PR DESCRIPTION
"jake -ls" pads out to the longest task name, even if that task
isn't being shown (either because it's excluded by an -ls filter,
or it lacks a description).

This fixes the padding to use the longest task name shown.