### PR TITLE
Add config.js file to define jake.exec() default options

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -14,20 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
+var util = require("util"), // Native Node util module
+  exec = require("child_process").exec,
+  spawn = require("child_process").spawn,
+  EventEmitter = require("events").EventEmitter,
+  utils = require("utilities"),
+  path = require("path"),
+  logger = require("./logger"),
+  Exec;
 
-var util = require('util') // Native Node util module
-  , exec = require('child_process').exec
-  , spawn = require('child_process').spawn
-  , EventEmitter = require('events').EventEmitter
-  , utils = require('utilities')
-  , logger = require('./logger')
-  , Exec;
-
-var execOptsDefault = (function() {
+var execOptsDefault = function (configPath) {
   try {
-    return require(`${process.cwd()}/config`).exec;
+    return require(configPath).exec;
   } catch (e) {
     return {
       interactive: false,
@@ -36,60 +36,61 @@ var execOptsDefault = (function() {
       breakOnError: true
     };
   }
-})();
+};
 
-var parseArgs = function(argumentsObj) {
+var parseArgs = function (argumentsObj) {
   var args,
     arg,
     cmds,
     callback,
-    opts = execOptsDefault;
+    opts = execOptsDefault(path.join(process.cwd(), "Jakeconfig.js"));
 
-    args = Array.prototype.slice.call(argumentsObj);
+  args = Array.prototype.slice.call(argumentsObj);
 
-    cmds = args.shift();
-    // Arrayize if passed a single string command
-    if (typeof cmds == 'string') {
-      cmds = [cmds];
-    }
-    // Make a copy if it's an actual list
-    else {
-      cmds = cmds.slice();
-    }
+  cmds = args.shift();
+  // Arrayize if passed a single string command
+  if (typeof cmds == "string") {
+    cmds = [cmds];
+  }
+  // Make a copy if it's an actual list
+  else {
+    cmds = cmds.slice();
+  }
 
-    // Get optional callback or opts
-    while((arg = args.shift())) {
-      if (typeof arg == 'function') {
-        callback = arg;
-      }
-      else if (typeof arg == 'object') {
-        utils.mixin(opts, arg);
-      }
+  // Get optional callback or opts
+  while ((arg = args.shift())) {
+    if (typeof arg == "function") {
+      callback = arg;
+    } else if (typeof arg == "object") {
+      utils.mixin(opts, arg);
     }
+  }
 
-    // Backward-compat shim
-    if (typeof opts.stdout != 'undefined') {
-      opts.printStdout = opts.stdout;
-      delete opts.stdout;
-    }
-    if (typeof opts.stderr != 'undefined') {
-      opts.printStderr = opts.stderr;
-      delete opts.stderr;
-    }
+  // Backward-compat shim
+  if (typeof opts.stdout != "undefined") {
+    opts.printStdout = opts.stdout;
+    delete opts.stdout;
+  }
+  if (typeof opts.stderr != "undefined") {
+    opts.printStderr = opts.stderr;
+    delete opts.stderr;
+  }
 
-    return {
-      cmds: cmds
-    , opts: opts
-    , callback: callback
-    };
+  return {
+    cmds: cmds,
+    opts: opts,
+    callback: callback
+  };
 };
 
 /**
   @name jake
   @namespace jake
 */
-utils.mixin(utils, new (function () {
-  /**
+utils.mixin(
+  utils,
+  new (function () {
+    /**
     @name jake.exec
     @static
     @function
@@ -119,35 +120,35 @@ utils.mixin(utils, new (function () {
         }
     jake.exec(cmds, {stdout: true}, callback);
    */
-  this.exec = function (a, b, c) {
-    var parsed = parseArgs(arguments)
-      , cmds = parsed.cmds
-      , opts = parsed.opts
-      , callback = parsed.callback;
+    this.exec = function (a, b, c) {
+      var parsed = parseArgs(arguments),
+        cmds = parsed.cmds,
+        opts = parsed.opts,
+        callback = parsed.callback;
 
-    var ex = new Exec(cmds, opts, callback);
+      var ex = new Exec(cmds, opts, callback);
 
-    ex.addListener('error', function (msg, code) {
-      if (opts.breakOnError) {
-        fail(msg, code);
-      }
-    });
-    ex.run();
+      ex.addListener("error", function (msg, code) {
+        if (opts.breakOnError) {
+          fail(msg, code);
+        }
+      });
+      ex.run();
 
-    return ex;
-  };
+      return ex;
+    };
 
-  this.createExec = function (a, b, c) {
-    return new Exec(a, b, c);
-  };
-
-})());
+    this.createExec = function (a, b, c) {
+      return new Exec(a, b, c);
+    };
+  })()
+);
 
 Exec = function () {
-  var parsed = parseArgs(arguments)
-    , cmds = parsed.cmds
-    , opts = parsed.opts
-    , callback = parsed.callback;
+  var parsed = parseArgs(arguments),
+    cmds = parsed.cmds,
+    opts = parsed.opts,
+    callback = parsed.callback;
 
   this._cmds = cmds;
   this._callback = callback;
@@ -156,111 +157,105 @@ Exec = function () {
 
 util.inherits(Exec, EventEmitter);
 
-utils.mixin(Exec.prototype, new (function () {
+utils.mixin(
+  Exec.prototype,
+  new (function () {
+    var _run = function () {
+      var self = this,
+        sh,
+        cmd,
+        args,
+        next = this._cmds.shift(),
+        config = this._config,
+        errData = "",
+        shStdio,
+        handleStdoutData = function (data) {
+          self.emit("stdout", data);
+        },
+        handleStderrData = function (data) {
+          var d = data.toString();
+          self.emit("stderr", data);
+          // Accumulate the error-data so we can use it as the
+          // stack if the process exits with an error
+          errData += d;
+        };
 
-  var _run = function () {
-        var self = this
-          , sh
-          , cmd
-          , args
-          , next = this._cmds.shift()
-          , config = this._config
-          , errData = ''
-          , shStdio
-          , handleStdoutData = function (data) {
-              self.emit('stdout', data);
-            }
-          , handleStderrData = function (data) {
-              var d = data.toString();
-              self.emit('stderr', data);
-              // Accumulate the error-data so we can use it as the
-              // stack if the process exits with an error
-              errData += d;
-            };
+      // Keep running as long as there are commands in the array
+      if (next) {
+        var spawnOpts = {};
+        this.emit("cmdStart", next);
 
-        // Keep running as long as there are commands in the array
-        if (next) {
-          var spawnOpts = {};
-          this.emit('cmdStart', next);
-
-          // Ganking part of Node's child_process.exec to get cmdline args parsed
-          if (process.platform == 'win32') {
-            cmd = 'cmd';
-            args = ['/c', next];
-            if (config.windowsVerbatimArguments) {
-              spawnOpts.windowsVerbatimArguments = true;
-            }
+        // Ganking part of Node's child_process.exec to get cmdline args parsed
+        if (process.platform == "win32") {
+          cmd = "cmd";
+          args = ["/c", next];
+          if (config.windowsVerbatimArguments) {
+            spawnOpts.windowsVerbatimArguments = true;
           }
-          else {
-            cmd = '/bin/sh';
-            args = ['-c', next];
-          }
-
-          if (config.interactive) {
-            spawnOpts.stdio = 'inherit';
-            sh = spawn(cmd, args, spawnOpts);
-          }
-          else {
-            shStdio = [
-              process.stdin
-            ];
-            if (config.printStdout) {
-              shStdio.push(process.stdout);
-            }
-            else {
-              shStdio.push('pipe');
-            }
-            if (config.printStderr) {
-              shStdio.push(process.stderr);
-            }
-            else {
-              shStdio.push('pipe');
-            }
-            spawnOpts.stdio = shStdio;
-            sh = spawn(cmd, args, spawnOpts);
-            if (!config.printStdout) {
-              sh.stdout.addListener('data', handleStdoutData);
-            }
-            if (!config.printStderr) {
-              sh.stderr.addListener('data', handleStderrData);
-            }
-          }
-
-          // Exit, handle err or run next
-          sh.on('exit', function (code) {
-            var msg;
-            if (code !== 0) {
-              msg = errData || 'Process exited with error.';
-              msg = utils.string.trim(msg);
-              self.emit('error', msg, code);
-            }
-            if (code === 0 || !config.breakOnError) {
-              self.emit('cmdEnd', next);
-              setTimeout(function () { _run.call(self); }, 0);
-            }
-          });
-
+        } else {
+          cmd = "/bin/sh";
+          args = ["-c", next];
         }
-        else {
-          self.emit('end');
-          if (typeof self._callback == 'function') {
-            self._callback();
+
+        if (config.interactive) {
+          spawnOpts.stdio = "inherit";
+          sh = spawn(cmd, args, spawnOpts);
+        } else {
+          shStdio = [process.stdin];
+          if (config.printStdout) {
+            shStdio.push(process.stdout);
+          } else {
+            shStdio.push("pipe");
+          }
+          if (config.printStderr) {
+            shStdio.push(process.stderr);
+          } else {
+            shStdio.push("pipe");
+          }
+          spawnOpts.stdio = shStdio;
+          sh = spawn(cmd, args, spawnOpts);
+          if (!config.printStdout) {
+            sh.stdout.addListener("data", handleStdoutData);
+          }
+          if (!config.printStderr) {
+            sh.stderr.addListener("data", handleStderrData);
           }
         }
-      };
 
-  this.append = function (cmd) {
-    this._cmds.push(cmd);
-  };
+        // Exit, handle err or run next
+        sh.on("exit", function (code) {
+          var msg;
+          if (code !== 0) {
+            msg = errData || "Process exited with error.";
+            msg = utils.string.trim(msg);
+            self.emit("error", msg, code);
+          }
+          if (code === 0 || !config.breakOnError) {
+            self.emit("cmdEnd", next);
+            setTimeout(function () {
+              _run.call(self);
+            }, 0);
+          }
+        });
+      } else {
+        self.emit("end");
+        if (typeof self._callback == "function") {
+          self._callback();
+        }
+      }
+    };
 
-  this.run = function () {
-    _run.call(this);
-  };
+    this.append = function (cmd) {
+      this._cmds.push(cmd);
+    };
 
-})());
+    this.run = function () {
+      _run.call(this);
+    };
+  })()
+);
 
 utils.Exec = Exec;
 utils.logger = logger;
 
 module.exports = utils;
-

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -25,17 +25,25 @@ var util = require('util') // Native Node util module
   , logger = require('./logger')
   , Exec;
 
-var parseArgs = function (argumentsObj) {
-    var args
-      , arg
-      , cmds
-      , callback
-      , opts = {
-          interactive: false
-        , printStdout: false
-        , printStderr: false
-        , breakOnError: true
-        };
+var execOptsDefault = (function() {
+  try {
+    return require(`${process.cwd()}/config`).exec;
+  } catch (e) {
+    return {
+      interactive: false,
+      printStdout: false,
+      printStderr: false,
+      breakOnError: true
+    };
+  }
+})();
+
+var parseArgs = function(argumentsObj) {
+  var args,
+    arg,
+    cmds,
+    callback,
+    opts = execOptsDefault;
 
     args = Array.prototype.slice.call(argumentsObj);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jake",
-  "version": "8.0.19",
+  "version": "8.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/__fixtures__/Jakeconfig.js
+++ b/test/__fixtures__/Jakeconfig.js
@@ -1,0 +1,8 @@
+module.exports = {
+  exec: {
+    interactive: true,
+    printStdout: true,
+    printStderr: true,
+    breakOnError: true
+  }
+};

--- a/test/exec.js
+++ b/test/exec.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
   , h = require('./helpers')
-  , utils = require('../lib/utils');
+  , utils = require('../lib/utils')
+  , fs = require('fs');
 
 utils.mixin(utils, utils);
 
@@ -109,6 +110,36 @@ var tests = {
     ex.run();
   }
 
+  , 'test options use default values when no config file passed': function (next) {
+    var ex = utils.createExec("ls", function () { });
+
+    var expected = {
+      interactive: false,
+      printStdout: false,
+      printStderr: false,
+      breakOnError: true
+    };
+    assert.deepStrictEqual(ex._config, expected);
+    next();
+  },
+
+  'test options use default values when a config file exists': function (next) {
+    var configFilePath = "Jakeconfig.js";
+
+    fs.copyFileSync("__fixtures__/Jakeconfig.js", configFilePath);
+    var ex = utils.createExec("ls", function () { });
+    fs.unlinkSync(configFilePath);
+
+    var expected = {
+      interactive: true,
+      printStdout: true,
+      printStderr: true,
+      breakOnError: true
+    };
+    assert.deepStrictEqual(ex._config, expected);
+    next();
+
+  }
 };
 
 module.exports = tests;


### PR DESCRIPTION
I edited the lib/utils/index.js to check if a file Jakeconfig.js exists in the current working directory.
If the file doesn't exists the fallback uses the default options initially set:
```
// lib/utils/index.js
var execOptsDefault = (function() {
  try {
    return require(`${process.cwd()}/Jakeconfig`).exec;
  } catch (e) {
    return {
      interactive: false,
      printStdout: false,
      printStderr: false,
      breakOnError: true
    };
  }
})();
```

```
//Jakeconfig.js
module.exports = {
  exec: {
    interactive: true,
    printStdout: true,
    printStderr: true,
    breakOnError: true
  }
};
```