### PR TITLE
fix "call stack size exceeded" with many prereqs

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -140,21 +140,23 @@ TaskBase = new (function () {
 
           //Test for circular invocation
           if(prereq === currenttask) {
-            async.setImmediate(function () {
+            setImmediate(function () {
               cb(new Error("Cannot use prereq " + prereq.name + " as a dependency of itself"));
             });
           }
 
           if (prereq.taskStatus === Task.runStatuses.DONE) {
             //prereq already done, return
-            async.setImmediate(function () {
+            setImmediate(function () {
               cb();
             });
           }
  else {
             //wait for complete before calling cb
             prereq.once('complete', function () {
-              cb();
+              setImmediate(function () {
+                cb();
+              });
             });
             //start te prereq if we are the first to encounter it
             if(prereq.taskStatus === Task.runStatuses.UNSTARTED) {

--- a/test/Jakefile
+++ b/test/Jakefile
@@ -366,18 +366,33 @@ namespace('test', function() {
 });
 
 namespace("large", function() {
-  desc("Leaf task");
-  task("leaf", [], function() {
+  task("leaf", function() {
     console.log("large:leaf");
   });
 
-  var leaves = [];
-  for (var i = 0; i < 5000; i++) {
-    leaves.push("large:leaf");
+  const same = [];
+  for (let i = 0; i < 2000; i++) {
+    same.push("leaf");
   }
 
-  desc("Task with a large number of prereqs");
-  task("root", leaves, {parallelLimit: 2}, function() {
-    console.log("large:root");
+  desc("Task with a large number of same prereqs");
+  task("same", same, { parallelLimit: 2 }, function () {
+    console.log("large:same");
   });
+
+  const different = [];
+  for (let i = 0; i < 2000; i++) {
+    const name = "leaf-" + i;
+    task(name, function () {
+      if (name === "leaf-12" || name === "leaf-123") {
+        console.log(name);
+      }
+    });
+    different.push(name);
+  }
+
+  desc("Task with a large number of different prereqs");
+  task("different", different, { parallelLimit: 2 } , function () {
+    console.log("large:different")
+  })
 });

--- a/test/task_base.js
+++ b/test/task_base.js
@@ -196,13 +196,19 @@ var tests = {
     });
   },
 
- 'test large number of prereqs': function (next) {
-    h.exec('../bin/cli.js large:root', function (out) {
-      assert.equal(out, 'large:leaf\nlarge:root');
+ 'test large number of same prereqs': function (next) {
+    h.exec('../bin/cli.js large:same', function (out) {
+      assert.equal(out, 'large:leaf\nlarge:same');
       next();
     });
-  }
+  },
 
+  'test large number of different prereqs': function (next) {
+    h.exec('../bin/cli.js large:different', function (out) {
+      assert.equal(out, 'leaf-12\nleaf-123\nlarge:different');
+      next();
+    });
+  },
 };
 
 function _getAutoCompleteOpts(args) {


### PR DESCRIPTION
When a task has a large number of prereqs and parallelLimit > 1,
each time a prereq finishes, it starts another prereq with a
recursive call, and this can overflow the nodejs stack.

The fix is to defer execution of the next prereq with setImmediate.

I had previously fixed this problem for some cases, but there
was a case that I missed.

This change fixes that case, and also adds a test that triggers
that case.