### PR TITLE
Improved exception handling when a child process fails

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -156,17 +156,19 @@ utils.mixin(Exec.prototype, new (function () {
     let args;
     let next = this._cmds.shift();
     let config = this._config;
-    let errData = '';
+    let errObj;
     let shStdio;
     let handleStdoutData = function (data) {
       self.emit('stdout', data);
     };
     let handleStderrData = function (data) {
-      let d = data.toString();
       self.emit('stderr', data);
+
       // Accumulate the error-data so we can use it as the
       // stack if the process exits with an error
-      errData += d;
+      if (!errObj) errObj = new Error();
+      let d = data.toString();
+      if (d) errObj.message += d;
     };
 
     // Keep running as long as there are commands in the array
@@ -219,11 +221,10 @@ utils.mixin(Exec.prototype, new (function () {
 
       // Exit, handle err or run next
       sh.on('exit', function (code) {
-        let msg;
         if (code !== 0) {
-          msg = errData || 'Process exited with error.';
-          msg = utils.string.trim(msg);
-          self.emit('error', msg, code);
+          if (!errObj.message) errObj.message = 'Process exited with error.';
+          errObj.message = utils.string.trim(errObj.message);
+          self.emit('error', errObj, code);
         }
         if (code === 0 || !config.breakOnError) {
           self.emit('cmdEnd', next);


### PR DESCRIPTION
Presently, if Jake fails due to a child process failing, the exception is very confusing. This is especially the case on Windows, where the "command not found" message takes up 2 lines.

This pull request changes how `Exec` handles errors by using a proper `Error` object instead of merely concatenating the output of `stderr`. As a result, `api.fail` will not attempt to build the `Error` object from scratch and potentially mutilate the child process's error message.

Example (without patch):
```
[paul@tempest:myproject]$ jake
jake aborted.
operable program or batch file.
(See full trace by running task with --trace)
[paul@tempest:myproject]$ jake --trace
jake aborted.
operable program or batch file.
```

Example (with patch):
```
[paul@tempest:myproject]$ jake
Starting 'lint'...
jake aborted.
Error: 'jshint' is not recognized as an internal or external command,
operable program or batch file.
    at Socket.handleStderrData (C:\Users\Paul\src\jake\lib\utils\index.js:169:29)
    at Socket.emit (events.js:198:13)
    at addChunk (_stream_readable.js:288:12)
    at readableAddChunk (_stream_readable.js:269:11)
    at Socket.Readable.push (_stream_readable.js:224:10)
    at Pipe.onStreamRead (internal/stream_base_commons.js:94:17)
```

Now, it is much more clear why the child process failed.