### PR TITLE
Fix handling of 'unhandledRejection' event

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -226,8 +226,8 @@ Program.prototype = new (function () {
     });
     if (!this.opts['allow-rejection']) {
       process.addListener('unhandledRejection', (reason, promise) => {
-        console.error('Unhandled rejection at:', promise, 'reason:', reason);
-        self.program.handleErr(reason);
+        utils.logger.error('Unhandled rejection at:', promise, 'reason:', reason);
+        self.handleErr(reason);
       });
     }
     if (this.envVars) {

--- a/test/jakefile.js
+++ b/test/jakefile.js
@@ -26,6 +26,22 @@ task('throwy', function () {
   throw new Error('I am bad');
 });
 
+desc('Task that rejects a Promise');
+task('promiseRejecter', function () {
+  const origialOption = jake.program.opts['allow-rejection'];
+
+  const errorListener = function (err) {
+    console.log(err.toString());
+    jake.removeListener('error', errorListener);
+    jake.program.opts['allow-rejection'] = origialOption; // Restore original 'allow-rejection' option
+  };
+  jake.on('error', errorListener);
+
+  jake.program.opts['allow-rejection'] = false; // Do not allow rejection so the rejection is passed to error handlers
+
+  Promise.reject('<promise rejected on purpose>');
+});
+
 desc('Accepts args and env vars.');
 task('argsEnvVars', function () {
   let res = {

--- a/test/task_base.js
+++ b/test/task_base.js
@@ -137,6 +137,11 @@ suite('taskBase', function () {
     assert(out.indexOf('Emitted\nError: I am bad') > -1);
   });
 
+  test('listening for jake unhandledRejection-event', function () {
+    let out = exec('./node_modules/.bin/jake -q promiseRejecter').toString().trim();
+    assert.equal(out, '<promise rejected on purpose>');
+  });
+
   test('large number of same prereqs', function () {
     let out = exec('./node_modules/.bin/jake -q large:same').toString().trim();
     assert.equal(out, 'large:leaf\nlarge:same');


### PR DESCRIPTION
I have stumbled upon this error:
> TypeError: Cannot read property 'handleErr' of undefined
    at process.addListener (/usr/local/lib/node_modules/jake/lib/program.js:228:22)
    at process.emit (events.js:197:13)
    at processPromiseRejections (internal/process/promises.js:139:20)
    at processTicksAndRejections (internal/process/next_tick.js:82:32)

I believe it was caused by this [change](https://github.com/jakejs/jake/commit/0c44184ab7d4bccdf88c2a545f6781b61c6451ee#diff-dc1c45f380eeb54be951137fa5f0eb59L292), the fix seems to be straightforward.