### PR TITLE
Adds feature to allow tasks to be greedy, consuming all remaining CLI…

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -267,6 +267,18 @@ Program.prototype = new (function () {
       }
     }
 
+    // if task sets option greedy, then add all remaining CLI params
+    // are consumed by the task and passed as arguments
+    taskNames = taskNames.reduceRight((accum, taskName) => {
+      let task = jake.rootNamespace.resolveTask(taskName);
+      if (task && task.greedy && accum.length) {
+        accum = [`${taskName}[${accum.join(",")}]`];
+      } else {
+        accum.unshift(taskName);
+      }
+      return accum;
+    }, []);
+
     rootTask = task(Task.ROOT_TASK_NAME, taskNames, function () {});
     rootTask._internal = true;
 

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -68,6 +68,7 @@ class Task extends EventEmitter {
     this.endTime = null;
     this.directory = null;
     this.namespace = null;
+    this.greedy = false;
 
     // Support legacy async-flag -- if not explicitly passed or falsy, will
     // be set to empty-object
@@ -80,6 +81,9 @@ class Task extends EventEmitter {
       }
       if (opts.concurrency) {
         this.concurrency = opts.concurrency;
+      }
+      if (opts.greedy) {
+        this.greedy = true;
       }
     }
 

--- a/test/integration/jakefile.js
+++ b/test/integration/jakefile.js
@@ -334,4 +334,10 @@ namespace("large", function () {
   task("different", different, { concurrency: 2 } , function () {
     console.log("large:different")
   })
+
 });
+
+desc("Task that greedily consumes all remaining CLI params");
+task("oink", { greedy: true } , function (...args) {
+  console.log("greedy task consumed", args.length, "remaining arguments: ", args);
+})

--- a/test/integration/task_base.js
+++ b/test/integration/task_base.js
@@ -161,4 +161,9 @@ suite('taskBase', function () {
     assert.equal('one:one\none:two', out);
   });
 
+  test('greedy task consumes all remaining CLI params as arguments', function () {
+    let out = exec('./node_modules/.bin/jake -q oink one two three').toString().trim();
+    assert.equal("greedy task consumed 3 remaining arguments:  [ \'one\', \'two\', \'three\' ]", out);
+  });
+
 });

--- a/test/unit/jakefile.js
+++ b/test/unit/jakefile.js
@@ -25,6 +25,10 @@ namespace('zooby', function () {
     });
 
     task('asdf', function () {});
+
+    task('zumm', { greedy: true }, function (args) {
+      console.log('ran zooby:frang:zumm');
+    });
   });
 
 });

--- a/test/unit/namespace.js
+++ b/test/unit/namespace.js
@@ -66,6 +66,7 @@ suite('namespace', function () {
     let curr = Namespace.ROOT_NAMESPACE.resolveNamespace('hurr:durr');
     let task = curr.resolveTask('zooby:frang:w00t:bar');
     assert.ok(task.action.toString().indexOf('zooby:frang:w00t:bar') > -1);
+    assert.ok(!task.greedy);
   });
 
   test('resolution miss with throw error', function () {
@@ -74,4 +75,10 @@ suite('namespace', function () {
     assert.ok(!task);
   });
 
+  test('resolution task with greedy option set', function () {
+    let curr = Namespace.ROOT_NAMESPACE;
+    let task = curr.resolveTask('zooby:frang:zumm');
+    assert.ok(task.action.toString().indexOf('zooby:frang:zumm') > -1);
+    assert.ok(task.greedy);
+  });
 });


### PR DESCRIPTION
… parameters.

Jake already accepts parameters via the [arg1,arg2] syntax, but this syntax is verbose, spacing sensitive and zsh forces use of backslashes: \[arg1,arg2\].  I'd prefer to be able to do this:

$ jake build core plugins web-client

Instead of:

$ jake build\[core,plugins,web-client\]

With this commit, if a task is declared with `greedy` option set, it will consume all remaining CLI params as arguments:

task('build', {greedy: true}, function(...args) {
   jake.exec("yarn build " + args.join(" "), {stdout: true, stderr: true});
})