### PR TITLE
adding parameters to -T output

### DIFF
--- a/lib/jake.js
+++ b/lib/jake.js
@@ -102,7 +102,7 @@ if (!global.jake) {
     };
 
     /**
-     * Displays the list of descriptions avaliable for tasks defined in
+     * Displays the list of descriptions available for tasks defined in
      * a Jakefile
      */
     this.showAllTaskDescriptions = function (f) {
@@ -113,6 +113,8 @@ if (!global.jake) {
       let name;
       let descr;
       let filter = typeof f == 'string' ? f : null;
+      let taskParams;
+      let len;
 
       for (p in jake.Task) {
         if (!Object.prototype.hasOwnProperty.call(jake.Task, p)) {
@@ -122,13 +124,17 @@ if (!global.jake) {
           continue;
         }
         task = jake.Task[p];
+        taskParams = task.params;
+
         // Record the length of the longest task name -- used for
         // pretty alignment of the task descriptions
         if (task.description) {
-          maxTaskNameLength = p.length > maxTaskNameLength ?
-            p.length : maxTaskNameLength;
+          len = p.length + taskParams.length;
+          maxTaskNameLength = len > maxTaskNameLength ?
+            len : maxTaskNameLength;
         }
       }
+
       // Print out each entry with descriptions neatly aligned
       for (p in jake.Task) {
         if (!Object.prototype.hasOwnProperty.call(jake.Task, p)) {
@@ -139,6 +145,11 @@ if (!global.jake) {
         }
         task = jake.Task[p];
 
+        taskParams = "";
+        if (task.params != "") {
+          taskParams = "[" + task.params + "]";
+        }
+
         //name = '\033[32m' + p + '\033[39m ';
         name = chalk.green(p);
 
@@ -147,9 +158,9 @@ if (!global.jake) {
           descr = chalk.gray('# ' + descr);
 
           // Create padding-string with calculated length
-          padding = (new Array(maxTaskNameLength - p.length + 2)).join(' ');
+          padding = (new Array(maxTaskNameLength - p.length - taskParams.length + 4)).join(' ');
 
-          console.log('jake ' + name + padding + descr);
+          console.log('jake ' + name + taskParams + padding + descr);
         }
       }
     };

--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -93,6 +93,10 @@ class Task extends EventEmitter {
     return this._getFullName();
   }
 
+  get params() {
+    return this._getParams();
+  }
+
   _initInvocationChain() {
     // Legacy global invocation chain
     jake._invocationChain.push(this);
@@ -412,6 +416,12 @@ class Task extends EventEmitter {
     }
     path.push(this.name);
     return path.join(':');
+  }
+
+  _getParams() {
+    if (!this.action) return "";
+    let params = new RegExp('(?:'+this.action.name+'\\s*|^)\\s*\\((.*?)\\)').exec(this.action.toString().replace(/\n/g, ''))[1].replace(/\/\*.*?\*\//g, '').replace(/ /g, '');
+    return params;
   }
 
   static getBaseNamespacePath(fullName) {


### PR DESCRIPTION
This pull request adds parameters to the `-T` output.

<img width="764" alt="Screen Shot 2021-01-06 at 9 47 34 AM" src="https://user-images.githubusercontent.com/1403427/103802650-51f47a80-5004-11eb-8700-d6acad72e41e.png">

It honors the spacing implementation, moving the description over to the right.

Please let me know if this is of interest, and if the code should be changed in any way.
