### PR TITLE
Add dash before options

### DIFF
--- a/usage.txt
+++ b/usage.txt
@@ -8,9 +8,9 @@ If no flags are given, Jake looks for a Jakefile or Jakefile.js in the current d
   -f,     --jakefile FILE            Use FILE as the Jakefile.
   -C,     --directory DIRECTORY      Change to DIRECTORY before running tasks.
   -B,     --always-make              Unconditionally make all targets.
-  -T/ls,  --tasks                 Display the tasks (matching optional PATTERN) with descriptions, then exit.
+  -T/-ls,  --tasks                 Display the tasks (matching optional PATTERN) with descriptions, then exit.
   -J,     --jakelibdir JAKELIBDIR    Auto-import any .jake files in JAKELIBDIR. (default is \'jakelib\')
   -h,     --help                     Display this help message.
-  -V/v,   --version                  Display the Jake version.
+  -V/-v,   --version                  Display the Jake version.
   -ar,    --allow-rejection          Keep running even after unhandled promise rejection
 


### PR DESCRIPTION
Help message contains mistakes: no `-` before options  `ls` and `v`

It's not intuitively understandable by using options
