### PR TITLE
Fix use of invoke() in concurrent tasks

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -224,11 +224,11 @@ class Task extends EventEmitter {
 
       // Do when done
       if (prereq.taskStatus == Task.runStatuses.DONE) {
-        self.handlePrereqDone(prereq);
+        self.handlePrereqDone(prereq, index);
       }
       else {
         prereq.once('_done', () => {
-          this.handlePrereqDone(prereq);
+          this.handlePrereqDone(prereq, index);
           prereq.removeAllListeners('_done');
         });
         if (prereq.taskStatus == Task.runStatuses.UNSTARTED) {
@@ -262,8 +262,8 @@ class Task extends EventEmitter {
     }
   }
 
-  handlePrereqDone(prereq) {
-    this._currentPrereqIndex++;
+  handlePrereqDone(prereq, index) {
+    this._currentPrereqIndex = Math.max(this._currentPrereqIndex, index + 1);
     if (this._currentPrereqIndex < this.prereqs.length) {
       setImmediate(this.nextPrereq.bind(this));
     }

--- a/test/integration/concurrent.js
+++ b/test/integration/concurrent.js
@@ -30,6 +30,12 @@ suite('concurrent', function () {
     assert.equal('Started A\nFinished A\nStarted Ba\nFinished Ba', out);
   });
 
+  test(' concurrent prerequisites with invoke', function () {
+    let out = exec('./node_modules/.bin/jake -q concurrent:invoke').toString().trim()
+    assert.equal('Started invoke1\nStarted invoke2\nStarted A\nStarted B\nFinished B\nFinished A\n' +
+                 'Started C\nStarted D\nFinished C\nFinished D\nFinished invoke1\nFinished invoke2', out);
+  });
+
   test(' failing in concurrent prerequisites', function () {
     try {
       exec('./node_modules/.bin/jake -q concurrent:Cfail');

--- a/test/integration/jakelib/concurrent.jake.js
+++ b/test/integration/jakelib/concurrent.jake.js
@@ -108,6 +108,33 @@ namespace('concurrent', function () {
     });
   });
 
+  task('invoke1', function () {
+    let t = jake.Task['concurrent:seqconcurrent'];
+
+    console.log('Started invoke1');
+    return new Promise((resolve) => {
+      t.addListener('complete', () => {
+        console.log('Finished invoke1');
+        resolve();
+      });
+      t.invoke();
+    });
+  });
+
+  task('invoke2', function () {
+    let t = jake.Task['concurrent:seqconcurrent'];
+
+    console.log('Started invoke2');
+    return new Promise((resolve) => {
+      t.addListener('complete', () => {
+        console.log('Finished invoke2');
+        resolve();
+      });
+      t.invoke();
+    });
+  });
+
+  task('invoke', ['invoke1', 'invoke2'], {concurrency: 2});
 });
 
 


### PR DESCRIPTION
Fix for #396 
I added a test case and wrote a quick fix. Note that this doesn't fix the duplicate calls to `handlePrereqDone`, but it prevents the index from being incremented twice. I don't think it's the best solution tbh, but it works.