### PR TITLE
use extension and object destructuring

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
 */
-let { uuid } = require('./utils');
+let { uuid } = require('./utils/index.js');
 
 let api = new (function () {
   /**

--- a/lib/jake.js
+++ b/lib/jake.js
@@ -18,23 +18,24 @@
 
 if (!global.jake) {
 
-  let EventEmitter = require('events').EventEmitter;
+  let EventEmitter = require('events');
   // And so it begins
   global.jake = new EventEmitter();
 
   let fs = require('fs');
   let chalk = require('chalk');
-  let taskNs = require('./task');
+  let taskNs = require('./task/index.js');
+  let {Rule} = require('./rule.js');
+  let {Namespace} = require('./namespace.js');
+  let {RootNamespace} = require('./namespace.js');
+  let api = require('./api.js');
+  let utils = require('./utils/index.js');
+  let {Program} = require('./program.js');
+  let loader = require('./loader.js')();
+
   let Task = taskNs.Task;
   let FileTask = taskNs.FileTask;
   let DirectoryTask = taskNs.DirectoryTask;
-  let Rule = require('./rule').Rule;
-  let Namespace = require('./namespace').Namespace;
-  let RootNamespace = require('./namespace').RootNamespace;
-  let api = require('./api');
-  let utils = require('./utils');
-  let Program = require('./program').Program;
-  let loader = require('./loader')();
   let pkg = JSON.parse(fs.readFileSync(__dirname + '/../package.json').toString());
 
   const MAX_RULE_RECURSION_LEVEL = 16;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -18,8 +18,8 @@
 
 let path = require('path');
 let fs = require('fs');
-let existsSync = fs.existsSync;
-let utils = require('./utils');
+let utils = require('./utils/index.js');
+let {existsSync} = fs;
 
 // Files like jakelib/foobar.jake.js
 const JAKELIB_FILE_PAT = /\.jake$|\.js$/;

--- a/lib/package_task.js
+++ b/lib/package_task.js
@@ -18,8 +18,8 @@
 
 let path = require('path');
 let fs = require('fs');
-let exec = require('child_process').exec;
-let FileList = require('filelist').FileList;
+let {exec} = require('child_process');
+let {FileList} = require('filelist');
 
 /**
   @name jake

--- a/lib/program.js
+++ b/lib/program.js
@@ -17,11 +17,12 @@
 */
 
 let fs = require('fs');
-let parseargs = require('./parseargs');
-let utils = require('./utils');
+let parseargs = require('./parseargs.js');
+let utils = require('./utils/index.js');
+let { Task } = require('./task/task.js');
+
+let usage = fs.readFileSync(`${__dirname}/../usage.txt`).toString();
 let Program;
-let usage = require('fs').readFileSync(`${__dirname}/../usage.txt`).toString();
-let { Task } = require('./task/task');
 
 function die(msg) {
   console.log(msg);

--- a/lib/publish_task.js
+++ b/lib/publish_task.js
@@ -18,8 +18,8 @@
 
 let fs = require('fs');
 let path = require('path');
-let exec = require('child_process').execSync;
-let FileList = require('filelist').FileList;
+let {execSync: exec} = require('child_process');
+let {FileList} = require('filelist');
 
 let PublishTask = function () {
   let args = Array.prototype.slice.call(arguments).filter(function (item) {

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,6 +1,6 @@
 let path = require('path');
 let fs = require('fs');
-let Task = require('./task/task').Task;
+let {Task} = require('./task/task.js');
 
 // Split a task to two parts, name space and task name.
 // For example, given 'foo:bin/a%.c', return an object with

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -18,10 +18,10 @@
 
 
 let util = require('util'); // Native Node util module
-let spawn = require('child_process').spawn;
-let EventEmitter = require('events').EventEmitter;
-let logger = require('./logger');
-let file = require('./file');
+let {spawn} = require('child_process');
+let EventEmitter = require('events');
+let logger = require('./logger.js');
+let file = require('./file.js');
 let Exec;
 
 const _UUID_CHARS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('');

--- a/test/integration/concurrent.js
+++ b/test/integration/concurrent.js
@@ -1,5 +1,5 @@
 let assert = require('assert');
-let exec = require('child_process').execSync;
+let {execSync: exec} = require('child_process');
 
 suite('concurrent', function () {
 

--- a/test/integration/file.js
+++ b/test/integration/file.js
@@ -23,7 +23,7 @@ let fs = require('fs');
 let path = require('path');
 let file = require(`${PROJECT_DIR}/lib/utils/file`);
 let existsSync = fs.existsSync || path.existsSync;
-let exec = require('child_process').execSync;
+let {execSync: exec} = require('child_process');
 
 suite('fileUtils', function () {
 

--- a/test/integration/file_task.js
+++ b/test/integration/file_task.js
@@ -20,7 +20,7 @@ const PROJECT_DIR = process.env.PROJECT_DIR;
 
 let assert = require('assert');
 let fs = require('fs');
-let exec = require('child_process').execSync;
+let {execSync: exec} = require('child_process');
 let { rmRf } = require(`${PROJECT_DIR}/lib/jake`);
 
 let cleanUpAndNext = function (callback) {

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -1,4 +1,4 @@
-var exec = require('child_process').exec;
+var {exec} = require('child_process');
 
 var helpers = new (function () {
   var _tests;

--- a/test/integration/jakelib/rule.jake.js
+++ b/test/integration/jakelib/rule.jake.js
@@ -16,11 +16,12 @@
  *
 */
 
-const PROJECT_DIR = process.env.PROJECT_DIR;
-
-let exec = require('child_process').execSync;
+let {execSync: exec} = require('child_process');
 let fs = require('fs');
 let util = require('util');
+
+const PROJECT_DIR = process.env.PROJECT_DIR;
+
 let { rule, rmRf } = require(`${PROJECT_DIR}/lib/jake`);
 
 directory('tmpsrc');

--- a/test/integration/publish_task.js
+++ b/test/integration/publish_task.js
@@ -1,12 +1,12 @@
 let assert = require('assert');
-let exec = require('child_process').execSync;
+let {execSync} = require('child_process');
 
 suite('publishTask', function () {
 
   this.timeout(7000);
 
   test('default task', function () {
-    let out = exec('./node_modules/.bin/jake  -q publish').toString().trim();
+    let out = execSync('./node_modules/.bin/jake  -q publish').toString().trim();
     let expected = [
       'Fetched remote tags.'
       , 'On branch v0.0'

--- a/test/integration/rule.js
+++ b/test/integration/rule.js
@@ -19,7 +19,7 @@
 const PROJECT_DIR = process.env.PROJECT_DIR;
 
 let assert = require('assert');
-let exec = require('child_process').execSync;
+let {execSync: exec} = require('child_process');
 let fs = require('fs');
 let { Rule } = require(`${PROJECT_DIR}/lib/rule`);
 let { rmRf } = require(`${PROJECT_DIR}/lib/jake`);

--- a/test/integration/selfdep.js
+++ b/test/integration/selfdep.js
@@ -1,5 +1,5 @@
 let assert = require('assert');
-let exec = require('child_process').execSync;
+let {execSync: exec} = require('child_process');
 
 suite('selfDep', function () {
 

--- a/test/integration/task_base.js
+++ b/test/integration/task_base.js
@@ -1,6 +1,6 @@
 let assert = require('assert');
-let h = require('./helpers');
-let exec = require('child_process').execSync;
+let {execSync: exec} = require('child_process');
+let h = require('./helpers.js');
 
 suite('taskBase', function () {
 


### PR DESCRIPTION
- using extension in relative imports
- move some require() calls to top
- use object destructuring where it uses require()

All of this is trends equally to how esm works, this PR don't change how the code works or breaks, it only makes it easier to make the switch to ESM when/if that times comes