### PR TITLE
Fix jake -T for directory  tasks

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -420,7 +420,7 @@ class Task extends EventEmitter {
 
   _getParams() {
     if (!this.action) return "";
-    let params = new RegExp('(?:'+this.action.name+'\\s*|^)\\s*\\((.*?)\\)').exec(this.action.toString().replace(/\n/g, ''))[1].replace(/\/\*.*?\*\//g, '').replace(/ /g, '');
+    let params = (new RegExp('(?:'+this.action.name+'\\s*|^)\\s*\\((.*?)\\)').exec(this.action.toString().replace(/\n/g, '')) || [,''])[1].replace(/\/\*.*?\*\//g, '').replace(/ /g, '');
     return params;
   }
 


### PR DESCRIPTION
Not sure if exactly `directory` or `packageTask` related, I have both and it breaks when I `jake -T`, all tasks run well still.  

So looks like it needs not to break in the negative case for the regexp, when nothing was matched. This fixes the problem.

Logged `this.action` and `this.action.name` and `this.action.toString()` values that break it.
```
$ jake -T
[Function: action]
{
  name: 'action',
  string: 'function () {\n          jake.mkdirP(name);\n        }'
}
```
Original stacktrace

```
TypeError: Cannot read properties of undefined (reading 'replace')
    at DirectoryTask._getParams (/Users/falsefalse/.nvm/versions/node/v16.16.0/lib/node_modules/jake/lib/task/task.js:426:10)
    at DirectoryTask.get params [as params] (/Users/falsefalse/.nvm/versions/node/v16.16.0/lib/node_modules/jake/lib/task/task.js:97:17)
    at EventEmitter.Object.assign.showAllTaskDescriptions (/Users/falsefalse/.nvm/versions/node/v16.16.0/lib/node_modules/jake/lib/jake.js:127:27)
    at Program.run (/Users/falsefalse/.nvm/versions/node/v16.16.0/lib/node_modules/jake/lib/program.js:250:19)
    at EventEmitter.Object.assign.run (/Users/falsefalse/.nvm/versions/node/v16.16.0/lib/node_modules/jake/lib/jake.js:323:17)
    at Object.<anonymous> (/Users/falsefalse/.nvm/versions/node/v16.16.0/lib/node_modules/jake/bin/cli.js:31:10)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
```