### PR TITLE
Fix task aborting due to incorrectly calculated timeout

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -295,7 +295,7 @@ class Task extends EventEmitter {
         if (!(this.reenabled && previous == this)) {
           if (previous.taskStatus != Task.runStatuses.DONE) {
             let now = (new Date()).getTime();
-            if (now - this.startTime > jake._taskTimeout) {
+            if (now - previous.startTime > jake._taskTimeout) {
               return jake.fail(`Timed out waiting for task: ${previous.name} with status of ${previous.taskStatus}`);
             }
             setTimeout(this.run.bind(this), POLLING_INTERVAL);


### PR DESCRIPTION
The timeout is being calculated with regard to another task, who often hasn't even started yet.