### PR TITLE
Remove skipped tasks from the stack.

### DIFF
--- a/lib/task/task.js
+++ b/lib/task/task.js
@@ -285,6 +285,8 @@ class Task extends EventEmitter {
     let hasAction = typeof this.action == 'function';
 
     if (!this.isNeeded()) {
+      jake._invocationChain.splice(jake._invocationChain.indexOf(this), 1);
+      
       this.emit('skip');
       this.emit('_done');
     }


### PR DESCRIPTION
_initInvocationChain pushes the task to the stack and is called on task.invoke and task.execute. When a task skips (like a file task does) the task.run() checks to see if it needs to be evaluated and if not, skips the task. Unfortunately it leaves the task on the stack causing some weird finished task messaging and can lead to early bailing.

Lets just pop the task from the stack when skipped.